### PR TITLE
feat(consume latest rust-fil-sector-builder SHA)

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -258,11 +258,22 @@ func AddPiece(
 	cPiecePath := C.CString(piecePath)
 	defer C.free(unsafe.Pointer(cPiecePath))
 
+	// TODO: The UTC time, in seconds, at which the sector builder can safely
+	// delete the piece. This allows for co-location of pieces with similar time
+	// constraints, and allows the sector builder to remove sectors containing
+	// pieces whose deals have expired.
+	//
+	// This value is currently ignored by the sector builder.
+	//
+	// https://github.com/filecoin-project/rust-fil-sector-builder/issues/32
+	pieceExpiryUtcSeconds := 0
+
 	resPtr := C.sector_builder_ffi_add_piece(
 		(*C.sector_builder_ffi_SectorBuilder)(sectorBuilderPtr),
 		cPieceKey,
 		C.uint64_t(pieceSize),
 		cPiecePath,
+		C.uint64_t(pieceExpiryUtcSeconds),
 	)
 	defer C.sector_builder_ffi_destroy_add_piece_response(resPtr)
 


### PR DESCRIPTION
## Changes in this PR

- pass dummy argument to `add_piece` (to conform to new API)
- submodule SHA bump

## Next Steps

Once merged, go-filecoin and go-lotus submodules should be updated to point at the new HEAD of master.

--------------

## rust-fil-sector-builder changes

```

-----------------------------------------------
commit 7ea193ff1681a2e0eec22779700840d996ff0a07
Author: laser <l@s3r.me>
Date:   Tue Aug 13 15:09:39 2019 -0700

    chore(sector-builder-ffi): release 0.5.0


-----------------------------------------------
commit 19382a4abd8fd5e72493801b5bd16b8a27a9e71a
Author: laser <l@s3r.me>
Date:   Tue Aug 13 15:05:28 2019 -0700

    chore(sector-builder): release 0.5.0


-----------------------------------------------
commit 53b53dc7208a4c636e10028e27e4ca0fc3499685
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Tue Aug 13 15:04:54 2019 -0700

    consume new 0.6.1 releases + update rust toolchain (#31)
    
    * feat(upgrade toolchain to match rust-fil-proofs)
    
    * fixup(point crates at Git branches during dev)
    
    * feat(consume new 0.6.0 releases)
    
    * feat(install paramcache from HEAD of master branch and compute Groth parameters)
    
    * feat(use chatty logging to see what's going on with sector builder)
    
    * feat(force install so that we don't explode if the binary already exists)
    
    * feat(consume new 0.6.1 patch release)
    
    * refactor(edits to accommodate new rust toolchain version)
    
    * feat(bump filecoin-proofs-ffi crate dependency)


-----------------------------------------------
commit 32587e2eac8e7105c3426d65e4aed840650e3806
Author: Steven Li <steven004@gmail.com>
Date:   Tue Aug 13 09:33:01 2019 +0800

    Meaningful sector name (#29)
    
    * Meaningful sector name
    
    * delete tar file which should not in
    
    * random naming is not used anymore
    
    * add sector_id to access creation function
    
    * refactor  with laser's comments
    
    * Added tests
    
    * to pass fmt check
    
    * format change for clippy pass


-----------------------------------------------
commit 92beb5aae0309dcca606ee92ef8c71df3c2cd910
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Wed Jul 31 23:34:56 2019 +0100

    make sector access a relative path, allowing miners to move sector and metadata directories (#16)
    
    * feat(don't persist sector path, but rather access - allows moving sector builder dir)
    
    * fixup(rust fmt)
    
    * bug(update test, which really should be rewritten)
    
    this test breaks the abstraction provided by the SectorManager by making assumptions about what sector access is (it assumes that it's a file path)
    
    * bug(more test updates)
    
    * bug(more test updates)
    
    * bug(more test updates)
    
    * bug(more test updates)
    
    * bug(more test updates)
    
    * refactor(refactor static method as free function as per @dig)


-----------------------------------------------
commit eaaae2995a893fe006d67f3195e03066024022aa
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Wed Jul 31 23:23:44 2019 +0100

    bug(set ENV such that we use parameters from cache) (#26)
    
    * bug(set ENV such that we use parameters from cache)
    
    * feat(use paramfetch instead of paramcache)


-----------------------------------------------
commit f5ac51b7739041d63a9345f0f0d13ab77762d91a
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Mon Jul 29 15:13:43 2019 +0200

    feat: switch to log crate


-----------------------------------------------
commit 9388fbca9ba8e85b8b73f12c20085753a03a131a
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Jul 29 02:03:14 2019 +0100

    feat(add piece expiry time, in secs since epoch, to API) (#20)


-----------------------------------------------
commit 558ad8e25f24a2798f96e0ab7d873cd4fb9061eb
Author: laser <l@s3r.me>
Date:   Thu Jul 25 05:36:05 2019 -0700

    chore(sector-builder-ffi): release 0.4.0


-----------------------------------------------
commit 6db83a91e4638ec43ded6126c2f83ecae248b879
Author: laser <l@s3r.me>
Date:   Thu Jul 25 05:05:48 2019 -0700

    chore(sector-builder): release 0.4.0


-----------------------------------------------
commit 200a49e92161a0d8d9f349660a9b434cec8070ff
Author: laser <l@s3r.me>
Date:   Thu Jul 25 05:05:31 2019 -0700

    chore(fil-proofs-tooling): release 0.5.0


-----------------------------------------------
commit 20ab93ed3dd4e75d36321091d44ce95959860c74
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Thu Jul 25 12:10:09 2019 +0100

    feat(upgrade upstream dependencies) (#14)
```

## rust-fil-proofs changes between filecoin-proofs 0.5.0 and filecoin-proofs 0.6.1

```

-----------------------------------------------
commit 4aaa61e90c7f7c94045990c84827978b8fc5d497
Author: laser <l@s3r.me>
Date:   Tue Aug 13 11:49:18 2019 -0700

    chore(filecoin-proofs): release 0.6.1


-----------------------------------------------
commit 95e35951c7bb110fec90f3c0e67eccdd971be5f4
Author: laser <l@s3r.me>
Date:   Tue Aug 13 11:49:17 2019 -0700

    chore(fil-proofs-tooling): release 0.6.1


-----------------------------------------------
commit 23b7b9fa9028ca29931844f15d21638799c54fb2
Author: laser <l@s3r.me>
Date:   Tue Aug 13 11:47:07 2019 -0700

    chore(storage-proofs): release 0.6.1


-----------------------------------------------
commit fac2d8aec7ed11f1a55a3c60a000f5cfff30fb1b
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Tue Aug 13 11:45:57 2019 -0700

    feat(replace rational PoSt params and keys with VDF PoSt) (#811)


-----------------------------------------------
commit 22519525e8bddad2c2f4bc676e257cbb45d4bdb1
Author: laser <l@s3r.me>
Date:   Tue Aug 13 08:45:28 2019 -0700

    chore(filecoin-proofs): release 0.6.0


-----------------------------------------------
commit 17b2fe3f5d5a619eff2d7208e518124778f74f4b
Author: laser <l@s3r.me>
Date:   Tue Aug 13 08:45:26 2019 -0700

    chore(fil-proofs-tooling): release 0.6.0


-----------------------------------------------
commit 07d6474c5a9e191a979bd64a1c5af034ec6bbf50
Author: laser <l@s3r.me>
Date:   Tue Aug 13 08:40:52 2019 -0700

    chore(storage-proofs): release 0.6.0


-----------------------------------------------
commit 4e220bb572f38aa854d8f559f7243c3608e363f8
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Aug 12 18:55:50 2019 -0700

    VDF PoSt: POST_SECTORS_COUNT to 512, from 2 (#807)
    
    * feat(breaking API change: replica path is required, not optional)
    
    * feat(bump POST_SECTORS_COUNT to 512 from 2)
    
    * refactor(revert to old API)
    
    * refactor(delete all the tests which assumed POST_SECTORS_COUNT of 2)
    
    These tests are useful, and I could rewrite them to work with the new POST_SECTORS_COUNT (or be more flexible), but we're going to delete this adapter when we switch to Rational PoSt.


-----------------------------------------------
commit d1b742850c153b281bc6801a6f27e1c3264b9926
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Aug 12 18:17:06 2019 -0700

    better remote benchmarking debug-output (#810)
    
    * feat(write loads of debug output to stdout when benchy or micro fails)
    
    * refactor(no need to pipe to jq, as scripts already do this)
    
    * refactor(collapse GTIME_BIN and GTIME_ARG into CMD + print stack trace)
    
    * refactor(print micro stack trace, too)
    
    * feat(check each exit code independently)


-----------------------------------------------
commit d7e5c52808d202d0268d6eae9bbd90464aacbb2d
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Aug 12 15:58:02 2019 -0700

    Feat/787 serialized benchmark runs (#793)
    
    * feat(add retry and with-lock scripts)
    
    * feat(try to acquire lock w/exponential backoff+retry before running benchmark)
    
    * bug(clean up on EXIT so as to not leak lock)
    
    * feat(debug output for relinquishing lock)
    
    * feat(shift it)
    
    * feat(force psuedoterminal allocation to ensure that cleanup runs if SSH tunnel is killed)
    
    * bug(fix documentation for backoff numbers)
    
    * docs(drop license)


-----------------------------------------------
commit 69ae1aeb4fcd64a17ed4bd34718ba10fc7ca70e1
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Aug 12 13:59:58 2019 -0700

    bug(update toolchain to work around broken issues with futures) (#808)
    
    * bug(update toolchain to work around broken issues with futures)
    
    * format(run cargo fmt using new toolchain)
    
    * refactory(appease clippy)
    
    * refactor(allow type_repetition_in_bounds to appease clippy)


-----------------------------------------------
commit 1182e68594806892b36d548d38473bcb33854571
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Wed Aug 7 21:50:38 2019 +0100

    feat(master builds should capture hash-constraints benchmarks) (#792)


-----------------------------------------------
commit 932e81e99eb1a539a7e074cf39a8ad4b0be44dd4
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Wed Aug 7 21:08:23 2019 +0200

    feat(fil-proofs-tooling): add constraints bench for blake2s and petersen
    
    Closes #785


-----------------------------------------------
commit 0150d2ef33f488486ab58e51cfbc853507883acc
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Wed Aug 7 19:43:27 2019 +0100

    feat(capture benchmarks on pushes to master) (#788)
    
    * feat(capture benchmarks on pushes to master)
    
    * feat(update fingerprint)
    
    * fixup(run metrics)
    
    * feat(consume RSA fingerprint from ENV)
    
    * bug(don't need to build binaries if we're not running locally)
    
    * feat(back to master)


-----------------------------------------------
commit 6ce60b867eddae8a939206d4e0664b9ee91af5f1
Merge: 3376d44 26a3a2c
Author: Sidney Keese <sidke.z@gmail.com>
Date:   Wed Aug 7 09:37:23 2019 -0700

    Merge pull request #783 from filecoin-project/features/configurable-window-size
    
    pass configurable window_size to jubjub


-----------------------------------------------
commit 26a3a2c841d33f198c82be1e6b3419c06eae7e80
Author: Sidney Keese <sidke.z@gmail.com>
Date:   Mon Aug 5 11:24:54 2019 -0700

    pass configurable window_size to jubjub


-----------------------------------------------
commit 3376d44f3bb7b6b474a433708307f2d647647ac1
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Wed Aug 7 03:38:37 2019 +0100

    feat(kebab-case instead of snakeCase) (#789)


-----------------------------------------------
commit ead0727fc0820c0fb3efdeb367a89b8e05ae1bdf
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Tue Aug 6 17:34:31 2019 +0200

    feat(filecoin-proofs): expose cache-identifiers for proof configs


-----------------------------------------------
commit 6776c3af73c06bfb73febc1f266013a42c924234
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Tue Aug 6 02:00:36 2019 +0100

    feat(run benchy remotely) (#780)
    
    * feat(benchy-remote, for running benchy.sh on a remote server)
    
    * feat(ignore benchy.sh output)
    
    * feat(write benchy-remote.sh output to stdout)
    
    * bug(build target-cpu native)
    
    * feat(update cargo run command to accommodate new Git repo-checking code)
    
    * bug(make sure to run the benchy.sh script, not the binary directly)
    
    * feat(ignore warnings on cargo bin run)
    
    * fixup(run special magic branch)
    
    * feat(pass --quiet flag)
    
    * fixup(revert to master branch)
    
    * feat(move RUSTFLAGS into scripts that require them)
    
    * feat(temporarily set RUSTFLAGS in environment)
    
    * fixup(swap branch temporarily)
    
    * feat(RUSTFLAGS in eval)
    
    * feat(RUSTFLAGS on same line)
    
    * fixup(revert to master)


-----------------------------------------------
commit 032a3316e64714eb2f36743aa896091642dcd6f9
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Aug 5 23:37:31 2019 +0100

    feat(run micro benchmarks remotely) (#782)
    
    * feat(run micro benchmarks remotely)
    
    * feat(run micro benchmark and zigzag/benchy on build)
    
    * feat(use environment key)
    
    * bug(must run benchy with 'cargo run' due to git environment-capturing code)
    
    * bug(cargo run --quiet to suppress build output)


-----------------------------------------------
commit 97509dc4f45b7352345f31dd7e73dbfbdd6093d5
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Aug 5 22:18:45 2019 +0100

    bug(transmute pico to microseconds) (#784)


-----------------------------------------------
commit 4ab9124505a7598294148db8aadb1c8efcf31bd1
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Mon Aug 5 21:29:43 2019 +0200

    feat(fil-proofs-tooling): collect benchmark metadata


-----------------------------------------------
commit b9044a889f6aaa20db646f74e62b3cdd022fd720
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Aug 5 17:15:07 2019 +0100

    bug(prefix time binary with env) (#779)


-----------------------------------------------
commit 46d471cf87a6c285085e324566c8e4a5fbb69e90
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Mon Aug 5 15:52:39 2019 +0100

    JSON output for micro benchmarks (#778)
    
    * feat(remove prometheus + add throughput + add unit of measure)
    
    - modify test to hit ms-to-us conversion code
    - add second test which parses output containing throughout and time
    
    * feat(mark throughput as optional)
    
    * feat(throughput and time median as point)


-----------------------------------------------
commit c561c7e00bee0d54341842250e9413ed066ac3d0
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Fri Aug 2 08:50:36 2019 +0100

    feat(fil-proofs-tooling): add total cpu time to zigzag


-----------------------------------------------
commit 315aff13231aff949d5e37a6b5d6b982f68b275a
Merge: a796349 1be1077
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Fri Aug 2 09:47:17 2019 +0200

    chore: publish params v11 (#773)
    
    chore: publish params v11


-----------------------------------------------
commit 1be10771c39723427cadbfbf994e609bc73ad054
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Thu Aug 1 21:11:46 2019 +0200

    chore: publish params v11


-----------------------------------------------
commit a79634992727621eecfe59b4d581ff2c968d5956
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Thu Aug 1 19:31:10 2019 +0100

    feat(zigzag benchmarking script which adds max RSS to output) (#772)
    
    * feat(zigzag benchmarking script which adds max RSS to output)
    
    * feat(propagate all args to benchy)
    
    * docs(add usage information to readme)


-----------------------------------------------
commit aa21593ab47284e1fa23f43a010486ef9981f7c5
Merge: 34507a2 9c458a0
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Thu Aug 1 17:48:22 2019 +0200

    docs: update readme for logging (#771)
    
    docs: update readme for logging


-----------------------------------------------
commit 34507a26e333bc666a24fd019bd8d44cc8baff4e
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Thu Aug 1 16:46:31 2019 +0100

    feat/672 wall clock and cpu time (#769)
    
    * bug(terminate left-over printlns)
    
    * feat(add CPU time to report)


-----------------------------------------------
commit 66debeddbc0d0d05ebbec93d03d74c33b5f60f4d
Merge: e4adb8d aef85c2
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Thu Aug 1 17:18:03 2019 +0200

    fix(examples): assert not equal after decoding (#770)
    
    fix(examples): assert not equal after decoding


-----------------------------------------------
commit 9c458a01ef6899f41e080175f2fe82016c9282cd
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Fri Jul 26 16:19:39 2019 +0100

    docs: update readme


-----------------------------------------------
commit aef85c262c87a5872fa4ab6ccd0e31f79563521d
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Thu Aug 1 16:12:10 2019 +0200

    fix(examples): assert not equal after decoding
    
    Closes #768


-----------------------------------------------
commit e4adb8d98f02ef9664b26f5e9849e803a49f9856
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Wed Jul 31 21:18:58 2019 +0100

    Feat/761 json output from benchy (#766)
    
    * feat(drop prometheus support)
    
    * feat(write report to stdout as JSON)
    
    * fixup(obey dig, the uberclippy)
    
    * feat(camel casing, as per porcu)


-----------------------------------------------
commit fbfb14ee9618f488c183f331da444293cf922168
Author: Sidney Keese <sidke.z@gmail.com>
Date:   Wed Jul 31 08:27:34 2019 -0700

    fix(filecoin-proofs): pass BadFrBytes error up instead of panicking


-----------------------------------------------
commit be1e4af8c0eda13aae6aa07d5a2107b87ee7b5bb
Author: RideWindX <ridewindx@163.com>
Date:   Wed Jul 31 22:53:40 2019 +0800

    feat(filecoin-proofs): add automatic proxy parameters to paramfetch


-----------------------------------------------
commit 0b155f96b471b5f4dc00936307f9704b5cde1864
Author: Erin Swenson-Healey <l@s3r.me>
Date:   Wed Jul 31 00:01:57 2019 +0100

    feat(move zigzag/benchy over to rust-proofs) (#765)


-----------------------------------------------
commit d19834d042d3a5716063efbd8c35b840966b6370
Merge: efcbbe6 05ac8b7
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Mon Jul 29 15:14:20 2019 +0200

    feat: remove unused sloth-iter (#758)
    
    feat: remove unused sloth-iter


-----------------------------------------------
commit 05ac8b7599486b8b6af9da0e06433376082fe6c9
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Mon Jul 29 13:11:32 2019 +0200

    update constraints


-----------------------------------------------
commit 07ff60f07ff89d88e47e6b84f92c7f794cc16f23
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Thu Jul 25 12:03:27 2019 +0100

    fix benches


-----------------------------------------------
commit d5d2c971568adfbe339a987db8c861a00ded6117
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Wed Jul 24 15:51:15 2019 +0100

    feat: remove unused sloth-iter
    
    We use sloth = 0 in all constructions, so this simplifies our code in that direction.


-----------------------------------------------
commit efcbbe64ce7b60df5ddc222972b1309a09163d4d
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Mon Jul 29 13:03:37 2019 +0200

    feat(storage-proofs): remove tree personalization


-----------------------------------------------
commit 42a422c6ea090349c438daf11388f5cbc5f2c5cb
Author: Lucas Molas <schomatis@gmail.com>
Date:   Mon Jul 29 11:33:23 2019 +0100

    docs: clarify REPLICATED_TREES_DIR relative path


-----------------------------------------------
commit 1daea67be56bd18d2cbd9d597073d9c4e48bb7fd
Merge: bbadd2d eb26e61
Author: Friedel Ziegelmayer <dignifiedquire@users.noreply.github.com>
Date:   Mon Jul 29 12:08:03 2019 +0200

    feat: switch to log crate (#760)
    
    feat: switch to log crate


-----------------------------------------------
commit eb26e61aa05f07d47e00da02af967275a969a78d
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Fri Jul 26 16:16:07 2019 +0100

    fixup


-----------------------------------------------
commit 02e98266a8a7e51152a04f3cb2986ef8c295c6bb
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Thu Jul 25 15:11:11 2019 +0100

    fixup


-----------------------------------------------
commit c7d6adfccaaefea708d722afd4b8fb65d098cbd6
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Thu Jul 25 13:12:51 2019 +0100

    refactor(fil-proofs-tooling): remove unused benchmarking tooling


-----------------------------------------------
commit 46ac6df4ac3ddeb2b729988bcf96db0f3c37d1cf
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Thu Jul 25 13:06:23 2019 +0100

    feat: remove logging-toolkit crate


-----------------------------------------------
commit 65973f60774df0dadc56b67c8ca008f886497393
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Thu Jul 25 13:04:49 2019 +0100

    feat(filecoin-proofs): switch to log crate


-----------------------------------------------
commit c9fcc9c6baadda91224b5d1e0211333a11029e8e
Author: dignifiedquire <dignifiedquire@users.noreply.github.com>
Date:   Thu Jul 25 12:36:22 2019 +0100

    feat(storage-proofs): switch to log crate


```