### PR TITLE
updates to consume new Rational PoSt API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
     steps:
       - run:
           name: Test project
-          command: go test
+          command: RUST_LOG=info go test
   restore_parameter_cache:
     steps:
       - restore_cache:

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -64,7 +64,7 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	require.Equal(t, 1, len(status.Pieces), "expected to see the one piece we added")
 
 	// verify the seal proof
-	isValid, err := sb.VerifySeal(1024, status.CommR, status.CommD, status.CommRStar, [31]byte{}, sectorIdAsBytes(sectorID), status.Proof)
+	isValid, err := sb.VerifySeal(1024, status.CommR, status.CommD, status.CommRStar, [31]byte{}, sectorID, status.Proof)
 	require.NoError(t, err)
 	require.True(t, isValid)
 
@@ -74,11 +74,11 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	require.True(t, isValid)
 
 	// generate a PoSt
-	proofs, faults, err := sb.GeneratePoSt(ptr, [][32]byte{status.CommR}, [32]byte{})
+	proofs, err := sb.GeneratePoSt(ptr, [][32]byte{status.CommR}, [32]byte{}, []uint64{})
 	require.NoError(t, err)
 
 	// verify the PoSt
-	isValid, err = sb.VerifyPoSt(1024, [][32]byte{status.CommR}, [32]byte{}, proofs, faults)
+	isValid, err = sb.VerifyPoSt(1024, [][32]byte{status.CommR}, []uint64{status.SectorID}, [32]byte{}, proofs, []uint64{})
 	require.NoError(t, err)
 	require.True(t, isValid)
 

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -73,12 +73,18 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, isValid)
 
+	// enforces sort ordering of SectorInfo tuples
+	sectorInfo := sb.NewSortedSectorInfo(sb.SectorInfo{
+		SectorID: status.SectorID,
+		CommR:    status.CommR,
+	})
+
 	// generate a PoSt
-	proofs, err := sb.GeneratePoSt(ptr, [][32]byte{status.CommR}, [32]byte{}, []uint64{})
+	proofs, err := sb.GeneratePoSt(ptr, sectorInfo, [32]byte{}, []uint64{})
 	require.NoError(t, err)
 
 	// verify the PoSt
-	isValid, err = sb.VerifyPoSt(1024, [][32]byte{status.CommR}, []uint64{status.SectorID}, [32]byte{}, proofs, []uint64{})
+	isValid, err = sb.VerifyPoSt(1024, sectorInfo, [32]byte{}, proofs, []uint64{})
 	require.NoError(t, err)
 	require.True(t, isValid)
 

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -3,7 +3,6 @@ package go_sectorbuilder_test
 import (
 	"bytes"
 	"crypto/rand"
-	"encoding/binary"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -128,16 +127,6 @@ func pollForSectorSealingStatus(ptr unsafe.Pointer, sectorID uint64, sealStatusC
 			}
 		}
 	}
-}
-
-func sectorIdAsBytes(sectorID uint64) [31]byte {
-	slice := make([]byte, 31)
-	binary.LittleEndian.PutUint64(slice, sectorID)
-
-	var sectorIDAsBytes [31]byte
-	copy(sectorIDAsBytes[:], slice)
-
-	return sectorIDAsBytes
 }
 
 func requireTempFilePath(t *testing.T, fileContentsReader io.Reader) string {

--- a/install-rust-fil-sector-builder
+++ b/install-rust-fil-sector-builder
@@ -20,7 +20,7 @@ if download_release_tarball tarball_path "${subm_dir}"; then
     mkdir -p bin
     cp "${tmp_dir}/bin/paramfetch" bin
 else
-    echo "failed to find or obtain precompiled assets for ${subm_dir}, falling back to local build"
+    (>&2 echo "failed to find or obtain precompiled assets for ${subm_dir} - falling back to local build")
     build_from_source "${subm_dir}"
 
     mkdir -p include
@@ -32,10 +32,19 @@ else
 
     pushd $subm_dir
 
-    # TODO https://github.com/filecoin-project/rust-fil-sector-builder/issues/39
-    FP_VERSION=$(cat "Cargo.lock" | grep 'name = "filecoin-proofs"' -A1 | tail -n1 | cut -d' ' -f3 | tr -d '"')
+    s="WARNING: paramfetch cannot be built from rust-fil-sector-builder "
+    s+="sources. Installing from HEAD of rust-fil-proofs master. The installed "
+    s+="version of paramfetch may be incompatible with your version of "
+    s+="rust-fil-sector-builder, which could result in you downloading "
+    s+="incompatible Groth parameters and verifying keys."
 
-    cargo install --version $FP_VERSION filecoin-proofs --root '..' --bin paramfetch
+    (>&2 echo s)
+    cargo install filecoin-proofs \
+      --bin paramfetch \
+      --force \
+      --git=https://github.com/filecoin-project/rust-fil-proofs.git \
+      --branch=master \
+      --root ".."
 
     popd
 fi

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -37,7 +37,7 @@ for attempt in `seq 1 $attempts`; do
 
     sleep_seconds=$(echo "scale=2; ${sleep_ms}/1000" | bc)
 
-    >&2 echo "sleeping ${sleep_seconds}s and then retrying ($((attempt + 1))/${attempts})"
+    (>&2 echo "sleeping ${sleep_seconds}s and then retrying ($((attempt + 1))/${attempts})")
 
     sleep "${sleep_seconds}"
 done

--- a/transforms.go
+++ b/transforms.go
@@ -120,11 +120,3 @@ func goPieceMetadata(src *C.sector_builder_ffi_FFIPieceMetadata, size C.size_t) 
 
 	return ps, nil
 }
-
-func goUint64s(src *C.uint64_t, size C.size_t) []uint64 {
-	out := make([]uint64, size)
-	if src != nil {
-		copy(out, (*(*[1 << 30]uint64)(unsafe.Pointer(src)))[:size:size])
-	}
-	return out
-}

--- a/transforms.go
+++ b/transforms.go
@@ -16,22 +16,6 @@ import "C"
 // with the number of partitions used when creating that proof.
 const SingleProofPartitionProofLen = 192
 
-func cPoStProofs(src [][]byte) (C.uint8_t, *C.uint8_t, C.size_t) {
-	proofSize := len(src[0])
-
-	flattenedLen := C.size_t(proofSize * len(src))
-
-	// flattening the byte slice makes it easier to copy into the C heap
-	flattened := make([]byte, flattenedLen)
-	for idx, proof := range src {
-		copy(flattened[(proofSize*idx):(proofSize*(1+idx))], proof[:])
-	}
-
-	proofPartitions := proofSize / SingleProofPartitionProofLen
-
-	return C.uint8_t(proofPartitions), (*C.uint8_t)(C.CBytes(flattened)), flattenedLen
-}
-
 func cUint64s(src []uint64) (*C.uint64_t, C.size_t) {
 	srcCSizeT := C.size_t(len(src))
 
@@ -47,11 +31,10 @@ func cUint64s(src []uint64) (*C.uint64_t, C.size_t) {
 	return (*C.uint64_t)(cUint64s), srcCSizeT
 }
 
-func cSectorClass(sectorSize uint64, poRepProofPartitions uint8, poStProofPartitions uint8) (C.sector_builder_ffi_FFISectorClass, error) {
+func cSectorClass(sectorSize uint64, poRepProofPartitions uint8) (C.sector_builder_ffi_FFISectorClass, error) {
 	return C.sector_builder_ffi_FFISectorClass{
 		sector_size:            C.uint64_t(sectorSize),
 		porep_proof_partitions: C.uint8_t(poRepProofPartitions),
-		post_proof_partitions:  C.uint8_t(poStProofPartitions),
 	}, nil
 }
 
@@ -136,20 +119,6 @@ func goPieceMetadata(src *C.sector_builder_ffi_FFIPieceMetadata, size C.size_t) 
 	}
 
 	return ps, nil
-}
-
-func goPoStProofs(partitions C.uint8_t, src *C.uint8_t, size C.size_t) ([][]byte, error) {
-	tmp := goBytes(src, size)
-
-	arraySize := len(tmp)
-	chunkSize := int(partitions) * SingleProofPartitionProofLen
-
-	out := make([][]byte, arraySize/chunkSize)
-	for i := 0; i < len(out); i++ {
-		out[i] = append([]byte{}, tmp[i*chunkSize:(i+1)*chunkSize]...)
-	}
-
-	return out, nil
 }
 
 func goUint64s(src *C.uint64_t, size C.size_t) []uint64 {


### PR DESCRIPTION
## Why does this PR exist?

Upstream `rust-fil-proofs` and `rust-fil-sector-builder` projects have moved away from the "VDF PoSt" construction, replacing it with Rational PoSt.

## What's in this PR?

This changeset updates the CGO bindings to reflect the new API as presented by `rust-fil-sector-builder`. Most importantly, miners need to call `generate_post` with the faults that they've detected. This differs from the old API in which `generate_post` would _return_ faults.

Other, less-interesting changes in this PR:

1. Sector id is now represented in the FFI an unsigned, 64-bit integer
1. PoStProofPartitions is now dead and removed from the FFI