### PR TITLE
expose sector health through CGO bindings

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -24,14 +24,16 @@ func elapsed(what string) func() {
 	}
 }
 
+// SealedSectorHealth represents the healthiness of a sector managed by a
+// sector builder.
 type SealedSectorHealth int
 
 const (
-	Unknown SealedSectorHealth = iota
-	Ok
-	ErrorInvalidChecksum
-	ErrorInvalidLength
-	ErrorMissing
+	Unknown              SealedSectorHealth = iota
+	Ok                                      // everything is fine
+	ErrorInvalidChecksum                    // sector exists, but checksum is invalid
+	ErrorInvalidLength                      // sector exists, but length is incorrect
+	ErrorMissing                            // sector no longer exists
 )
 
 // SortedSectorInfo is a slice of SectorInfo sorted (lexicographically,

--- a/bindings.go
+++ b/bindings.go
@@ -386,7 +386,7 @@ func GetAllStagedSectors(sectorBuilderPtr unsafe.Pointer) ([]StagedSectorMetadat
 func GetAllSealedSectors(sectorBuilderPtr unsafe.Pointer, performHealthchecks bool) ([]SealedSectorMetadata, error) {
 	defer elapsed("GetAllSealedSectors")()
 
-	resPtr := C.sector_builder_ffi_get_sealed_sectors((*C.sector_builder_ffi_SectorBuilder)(sectorBuilderPtr), performHealthchecks)
+	resPtr := C.sector_builder_ffi_get_sealed_sectors((*C.sector_builder_ffi_SectorBuilder)(sectorBuilderPtr), true == performHealthchecks)
 	defer C.sector_builder_ffi_destroy_get_sealed_sectors_response(resPtr)
 
 	if resPtr.status_code != 0 {

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -87,12 +87,13 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, isValid)
 
-	sealedSectors, err := sb.GetAllSealedSectors(ptr)
+	sealedSectors, err := sb.GetAllSealedSectors(ptr, true)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sealedSectors), "expected to see one sealed sector")
 	sealedSector := sealedSectors[0]
 	require.Equal(t, uint64(1), sealedSector.SectorID)
 	require.Equal(t, 1, len(sealedSector.Pieces))
+	require.Equal(t, sb.Ok, sealedSector.Health)
 	// the piece is the size of the sector, so its piece commitment should be the
 	// data commitment
 	require.Equal(t, commP, sealedSector.CommD)

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -30,6 +30,11 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	defer sb.DestroySectorBuilder(ptr)
 
+	// verify that we've not yet sealed a sector
+	sealedSectors, err := sb.GetAllSealedSectorsWithHealth(ptr)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(sealedSectors), "expected to see zero sealed sectors")
+
 	// compute the max user-bytes that can fit into a staged sector such that
 	// bit-padding ("preprocessing") expands the file to $SECTOR_SIZE
 	maxPieceSize := sb.GetMaxUserBytesPerStagedSector(1024)
@@ -87,7 +92,7 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, isValid)
 
-	sealedSectors, err := sb.GetAllSealedSectors(ptr, true)
+	sealedSectors, err = sb.GetAllSealedSectorsWithHealth(ptr)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(sealedSectors), "expected to see one sealed sector")
 	sealedSector := sealedSectors[0]

--- a/transforms.go
+++ b/transforms.go
@@ -129,15 +129,15 @@ func goPieceMetadata(src *C.sector_builder_ffi_FFIPieceMetadata, size C.size_t) 
 
 func goSealedSectorHealth(health C.sector_builder_ffi_FFISealedSectorHealth) (SealedSectorHealth, error) {
 	switch health {
-	case C.sector_builder_ffi_FFISealedSectorHealth_Unknown:
+	case C.Unknown:
 		return Unknown, nil
-	case C.sector_builder_ffi_FFISealedSectorHealth_Ok:
+	case C.Ok:
 		return Ok, nil
-	case C.sector_builder_ffi_FFISealedSectorHealth_ErrorInvalidChecksum:
+	case C.ErrorInvalidChecksum:
 		return ErrorInvalidChecksum, nil
-	case C.sector_builder_ffi_FFISealedSectorHealth_ErrorInvalidLength:
+	case C.ErrorInvalidLength:
 		return ErrorInvalidLength, nil
-	case C.sector_builder_ffi_FFISealedSectorHealth_ErrorMissing:
+	case C.ErrorMissing:
 		return ErrorMissing, nil
 	default:
 		return Unknown, errors.Errorf("unhandled sealed sector health: %v", health)

--- a/transforms.go
+++ b/transforms.go
@@ -85,6 +85,11 @@ func goSealedSectorMetadata(src *C.sector_builder_ffi_FFISealedSectorMetadata, s
 			return []SealedSectorMetadata{}, errors.Wrap(err, "failed to marshal piece metadata")
 		}
 
+		health, err := goSealedSectorHealth(ptrs[i].health)
+		if err != nil {
+			return []SealedSectorMetadata{}, errors.Wrap(err, "failed to marshal sealed sector health")
+		}
+
 		sectors[i] = SealedSectorMetadata{
 			SectorID:  uint64(ptrs[i].sector_id),
 			CommD:     commD,
@@ -92,6 +97,7 @@ func goSealedSectorMetadata(src *C.sector_builder_ffi_FFISealedSectorMetadata, s
 			CommRStar: commRStar,
 			Proof:     proof,
 			Pieces:    pieces,
+			Health:    health,
 		}
 	}
 
@@ -119,4 +125,21 @@ func goPieceMetadata(src *C.sector_builder_ffi_FFIPieceMetadata, size C.size_t) 
 	}
 
 	return ps, nil
+}
+
+func goSealedSectorHealth(health C.sector_builder_ffi_FFISealedSectorHealth) (SealedSectorHealth, error) {
+	switch health {
+	case C.sector_builder_ffi_FFISealedSectorHealth_Unknown:
+		return Unknown, nil
+	case C.sector_builder_ffi_FFISealedSectorHealth_Ok:
+		return Ok, nil
+	case C.sector_builder_ffi_FFISealedSectorHealth_ErrorInvalidChecksum:
+		return ErrorInvalidChecksum, nil
+	case C.sector_builder_ffi_FFISealedSectorHealth_ErrorInvalidLength:
+		return ErrorInvalidLength, nil
+	case C.sector_builder_ffi_FFISealedSectorHealth_ErrorMissing:
+		return ErrorMissing, nil
+	default:
+		return Unknown, errors.Errorf("unhandled sealed sector health: %v", health)
+	}
 }


### PR DESCRIPTION
## Why does this PR exist?

Rational PoSt requires that miners detect and report storage faults before generating a PoSt.

## What's in this PR?

This PR exposes a sector's health through the `GetAllSealedSectors` operation. If a miner wishes the sector builder to check the health of the sectors which it manages, it does so by passing `performHealthchecks=true`. If it passes `false`, no healthchecks will be run.