### PR TITLE
feat: implement AddPieceFromFile and GeneratePieceCommitmentFromFile

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -280,14 +280,14 @@ func DestroySectorBuilder(sectorBuilderPtr unsafe.Pointer) {
 	C.sector_builder_ffi_destroy_sector_builder((*C.sector_builder_ffi_SectorBuilder)(sectorBuilderPtr))
 }
 
-// AddPieceFromPath writes the given piece into an unsealed sector and returns the id of that sector.
-func AddPieceFromPath(
+// AddPiece writes the given piece into an unsealed sector and returns the id of that sector.
+func AddPiece(
 	sectorBuilderPtr unsafe.Pointer,
 	pieceKey string,
 	pieceBytes uint64,
 	piecePath string,
 ) (uint64, error) {
-	defer elapsed("AddPieceFromPath")()
+	defer elapsed("AddPiece")()
 
 	pieceFile, err := os.Open(piecePath)
 	if err != nil {
@@ -547,9 +547,9 @@ func VerifyPieceInclusionProof(sectorSize uint64, pieceSize uint64, commP [Commi
 	return bool(resPtr.is_valid), nil
 }
 
-// GeneratePieceCommitmentFromPath produces a piece commitment for the provided data
+// GeneratePieceCommitment produces a piece commitment for the provided data
 // stored at a given path.
-func GeneratePieceCommitmentFromPath(piecePath string, pieceSize uint64) ([CommitmentBytesLen]byte, error) {
+func GeneratePieceCommitment(piecePath string, pieceSize uint64) ([CommitmentBytesLen]byte, error) {
 	pieceFile, err := os.Open(piecePath)
 	if err != nil {
 		return [CommitmentBytesLen]byte{}, err

--- a/bindings.go
+++ b/bindings.go
@@ -324,7 +324,7 @@ func AddPieceFromFile(
 	resPtr := C.sector_builder_ffi_add_piece(
 		(*C.sector_builder_ffi_SectorBuilder)(sectorBuilderPtr),
 		cPieceKey,
-		unsafe.Pointer(pieceFd),
+		C.int(pieceFd),
 		C.uint64_t(pieceBytes),
 		C.uint64_t(pieceExpiryUtcSeconds),
 	)
@@ -563,7 +563,7 @@ func GeneratePieceCommitment(piecePath string, pieceSize uint64) ([CommitmentByt
 func GeneratePieceCommitmentFromFile(pieceFile *os.File, pieceSize uint64) (commP [CommitmentBytesLen]byte, err error) {
 	pieceFd := pieceFile.Fd()
 
-	resPtr := C.sector_builder_ffi_generate_piece_commitment(unsafe.Pointer(pieceFd), C.uint64_t(pieceSize))
+	resPtr := C.sector_builder_ffi_generate_piece_commitment(C.int(pieceFd), C.uint64_t(pieceSize))
 	defer C.sector_builder_ffi_destroy_generate_piece_commitment_response(resPtr)
 
 	// Make sure our filedescriptor stays alive, stayin alive

--- a/bindings.go
+++ b/bindings.go
@@ -1,13 +1,10 @@
 package go_sectorbuilder
 
 import (
-<<<<<<< HEAD
 	"bytes"
-	"sort"
-=======
 	"os"
 	"runtime"
->>>>>>> fet: use filedescriptors for add_piece and generate_piece_commitment
+	"sort"
 	"time"
 	"unsafe"
 

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -1,7 +1,6 @@
 package go_sectorbuilder_test
 
 import (
-	"fmt"
 	"bytes"
 	"crypto/rand"
 	"errors"
@@ -55,9 +54,6 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	commP, err := sb.GeneratePieceCommitmentFromFile(pieceFile, maxPieceSize)
 	require.NoError(t, err)
 
-	info, err := pieceFile.Stat()
-	require.NoError(t, err)
-	fmt.Printf("info %v\n", info)
 	// seek to the beginning
 	_, err = pieceFile.Seek(0, 0)
 	require.NoError(t, err)

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -46,15 +46,15 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	pieceBytes := make([]byte, maxPieceSize)
 	_, err = io.ReadFull(rand.Reader, pieceBytes)
 	require.NoError(t, err)
-	piecePath := requireTempFilePath(t, bytes.NewReader(pieceBytes))
+	pieceFile := requireTempFile(t, bytes.NewReader(pieceBytes))
 
 	// generate piece commitment
-	commP, err := sb.GeneratePieceCommitment(piecePath, maxPieceSize)
+	commP, err := sb.GeneratePieceCommitment(pieceFile, maxPieceSize)
 	require.NoError(t, err)
 
 	// write a piece to a staged sector, reducing remaining space to 0 and
 	// triggering the seal job
-	sectorID, err := sb.AddPiece(ptr, "snoqualmie", maxPieceSize, piecePath)
+	sectorID, err := sb.AddPiece(ptr, "snoqualmie", maxPieceSize, pieceFile)
 	require.NoError(t, err)
 
 	stagedSectors, err := sb.GetAllStagedSectors(ptr)
@@ -137,14 +137,14 @@ func pollForSectorSealingStatus(ptr unsafe.Pointer, sectorID uint64, targetState
 	}
 }
 
-func requireTempFilePath(t *testing.T, fileContentsReader io.Reader) string {
+func requireTempFile(t *testing.T, fileContentsReader io.Reader) os.File {
 	file, err := ioutil.TempFile("", "")
 	require.NoError(t, err)
 
 	_, err = io.Copy(file, fileContentsReader)
 	require.NoError(t, err)
 
-	return file.Name()
+	file
 }
 
 func requireTempDirPath(t *testing.T) string {


### PR DESCRIPTION
Depends on https://github.com/filecoin-project/rust-fil-sector-builder/pull/53

Closes #2 

Changes the api so there is 
- `AddPiece` (existing api) and `AddPieceFromFile`
- `GeneratePieceCommitment` (existing api) and `GeneratePieceCommitmentFromFile`

This way users that want to keep using the `string` argument can stick with the `Path` options.