### PR TITLE
feat(tarball): always download release tarball

### DIFF
--- a/install-shared.bash
+++ b/install-shared.bash
@@ -24,21 +24,19 @@ download_release_tarball() {
 
     __tar_path="/tmp/${__release_name}_$(basename ${__release_url}).tar.gz"
 
-    if [[ ! -f "${__tar_path}" ]]; then
-        __asset_url=$(curl \
-            --head \
-            --retry 3 \
-            --header "Accept:application/octet-stream" \
-            --location \
-            --output /dev/null \
-            -w %{url_effective} \
-            "$__release_url")
+    __asset_url=$(curl \
+        --head \
+        --retry 3 \
+        --header "Accept:application/octet-stream" \
+        --location \
+        --output /dev/null \
+        -w %{url_effective} \
+        "$__release_url")
 
-        curl --retry 3 --output "${__tar_path}" "$__asset_url"
-        if [[ $? -ne "0" ]]; then
-            (>&2 echo "failed to download release asset (tag URL: ${__release_tag_url}, asset URL: ${__asset_url})")
-            return 1
-        fi
+    curl --retry 3 --output "${__tar_path}" "$__asset_url"
+    if [[ $? -ne "0" ]]; then
+        (>&2 echo "failed to download release asset (tag URL: ${__release_tag_url}, asset URL: ${__asset_url})")
+        return 1
     fi
 
     eval $__resultvar="'$__tar_path'"


### PR DESCRIPTION
## Why does this PR exist?

If a corrupted tarball is written to `/tmp` and the build script exits, the script gets into a bad state.

## What's in this PR?

Don't get smart about caching downloaded tarballs. Get dumb.