### PR TITLE
ci(fallback): don't fall back to local Rust build if precompiled assets not available

### DIFF
--- a/install-rust-fil-sector-builder
+++ b/install-rust-fil-sector-builder
@@ -19,15 +19,20 @@ if download_release_tarball tarball_path "${subm_dir}"; then
 
     cp "${tmp_dir}/bin/paramcache" .
 else
-    (>&2 echo "failed to find or obtain precompiled assets for ${subm_dir} - falling back to local build")
-    build_from_source "${subm_dir}"
+    if [ $CI = "true" ]; then
+        (>&2 echo "failed to find or obtain precompiled assets for ${subm_dir} - falling back to local build")
+        build_from_source "${subm_dir}"
 
-    mkdir -p include
-    mkdir -p lib/pkgconfig
+        mkdir -p include
+        mkdir -p lib/pkgconfig
 
-    find "${subm_dir}" -type f -name sector_builder_ffi.h -exec cp -- "{}" . \;
-    find "${subm_dir}" -type f -name libsector_builder_ffi.a -exec cp -- "{}" . \;
-    find "${subm_dir}" -type f -name sector_builder_ffi.pc -exec cp -- "{}" . \;
+        find "${subm_dir}" -type f -name sector_builder_ffi.h -exec cp -- "{}" . \;
+        find "${subm_dir}" -type f -name libsector_builder_ffi.a -exec cp -- "{}" . \;
+        find "${subm_dir}" -type f -name sector_builder_ffi.pc -exec cp -- "{}" . \;
 
-    (>&2 echo "WARNING: paramcache was not installed - you may wish to 'cargo install' it")
+        (>&2 echo "WARNING: paramcache was not installed - you may wish to 'cargo install' it")
+    else
+        (>&2 echo "build failed: could not obtain precompiled assets for ${subm_dir} - contact @laser or @dignifiedquire")
+        exit 1
+    fi
 fi


### PR DESCRIPTION
## Why does this PR exist?

The existing build script for go-sectorbuilder attempts to build Rust sources if no precompiled rust-fil-sector-builder release is available for the given submodule SHA. Due to our existing Rust release pipeline (where each repo is pointed at its upstream dependencies' master HEAD), rust-fil-sector-builder master isn't always in a buildable state.

## What's in this PR?

This PR disables local build fallback for non-CI environments. Programmers who need to build from source may do so by setting the `CI` environment variable to `true`.