### PR TITLE
sort CommRs by sector id

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -1,7 +1,6 @@
 package go_sectorbuilder
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"runtime"
@@ -39,7 +38,7 @@ type SortedSectorInfo struct {
 // NewSortedSectorInfo returns a SortedSectorInfo
 func NewSortedSectorInfo(sectorInfo ...SectorInfo) SortedSectorInfo {
 	fn := func(i, j int) bool {
-		return bytes.Compare(sectorInfo[i].CommR[:], sectorInfo[j].CommR[:]) == -1
+		return sectorInfo[i].SectorID < sectorInfo[j].SectorID
 	}
 
 	sort.Slice(sectorInfo[:], fn)


### PR DESCRIPTION
Fixes #23 

## Why does this PR exist?

PoSt generation and verification require their input CommRs be provided in the same order. @whyrusleeping pointed out that we're sorting on replica-bytes and we could be sorting by sector id instead.

## What's in this PR?

This PR updates the sorter to use sector id instead of bytes, and adds a JSON marshal/unmarshal method pair as per @anorth.