### PR TITLE
conform to new DRG+ API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,11 +116,11 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v14-proof-params
+            - v14b-proof-params
   save_parameter_cache:
     steps:
       - save_cache:
-          key: v14-proof-params
+          key: v14b-proof-params
           paths:
             - "~/filecoin-proof-parameters/"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
       - update_submodules
       - build_project
       - lint_project
-      - generate_parameter_checksum
       - restore_parameter_cache
       - obtain_filecoin_parameters
       - save_parameter_cache
@@ -58,7 +57,6 @@ jobs:
       - update_submodules
       - build_project
       - lint_project
-      - generate_parameter_checksum
       - restore_parameter_cache
       - obtain_filecoin_parameters
       - save_parameter_cache
@@ -118,16 +116,11 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v2-proof-params-{{ checksum "parameter-checksum.txt" }}
+            - v14-proof-params
   save_parameter_cache:
     steps:
       - save_cache:
-          key: v2-proof-params-{{ checksum "parameter-checksum.txt" }}
+          key: v14-proof-params
           paths:
             - "~/filecoin-proof-parameters/"
-  generate_parameter_checksum:
-    steps:
-      - run:
-          name: create parameter cache checksum
-          command: md5sum ./paramcache | cut -d ' ' -f 1 >> parameter-checksum.txt
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/golangci/golangci-lint v1.17.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/ipfs/go-log v0.0.1
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/neelance/parallel v0.0.0-20160708114440-4de9ce63d14c // indirect
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/install-shared.bash
+++ b/install-shared.bash
@@ -64,7 +64,6 @@ build_from_source() {
     pushd $__submodule_path
 
     cargo --version
-    cargo update
 
     if [[ -f "./scripts/build-release.sh" ]]; then
         ./scripts/build-release.sh $(cat rust-toolchain)

--- a/sealing_state/state.go
+++ b/sealing_state/state.go
@@ -4,11 +4,13 @@ package sealing_state
 type State int
 
 const (
-	Unknown State = iota
-	Pending       // sector is still accepting user data
-	Failed        // sealing failed
-	Sealing       // sector is currently being sealed
-	Sealed        // sector has been sealed successfully
+	Unknown         State = iota
+	Pending               // sector is still accepting user data
+	Failed                // sealing failed
+	Sealing               // sector is currently being sealed
+	Sealed                // sector has been sealed successfully
+	Paused                // sector sealing has been paused and can be resumed
+	ReadyForSealing       // staged sector is full and is ready to seal
 )
 
 var labels = [...]string{
@@ -17,6 +19,8 @@ var labels = [...]string{
 	"Failed",
 	"Sealing",
 	"Sealed",
+	"Paused",
+	"ReadyForSealing",
 }
 
 func (el State) String() string {


### PR DESCRIPTION
## Why does this PR exist?

We've updated the rust-fil-proofs and rust-fil-sector-builder APIs to accept a ticket (commits the sector to a particular subchain) and need to update go-sectorbuilder bindings accordingly.

## What's in this PR?

This PR changes the way that seal operations are scheduled. In the past, the seal operation would be scheduled in response to a staged sector having become full with user piece-data ("full" being defined by the sector builder implementation).

Now, consumers of this API will call `seal_sector(id, ticket)` when a sector's status is `ReadyForSealing` (indicating that it is full) or `Pending` (indicating that it is not yet full). If the sector builder dies in the middle of sealing, the consumer will need to call `resume_seal_sector(id)`.

The `resume_seal_sector`, `seal_sector`, and `seal_all_staged_sectors` methods now block until they have finished sealing (either successfully or by failing).

## A Thing Which May Surprise You

- The `seal_sector` method will produce an error if given the id of a sector which is not in the `ReadyToSeal` or `Pending` state. This state is reached when the sector builder has packed sufficient data in to it. Is it not an idempotent operation (should it be?).
- The `resume_seal_sector` method will produce an error if given the id of a sector which is not in the `Paused` state. It is not an idempotent operation (should it be?). Currently this state is reached only when the sector builder restarts after being terminated mid-way through sealing a sector.