### PR TITLE
provide sector cache root directory to sector builder constructor

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -248,12 +248,12 @@ func GetMaxUserBytesPerStagedSector(sectorSize uint64) uint64 {
 func InitSectorBuilder(
 	sectorSize uint64,
 	poRepProofPartitions uint8,
-	poStProofPartitions uint8,
 	lastUsedSectorID uint64,
 	metadataDir string,
 	proverID [32]byte,
 	sealedSectorDir string,
 	stagedSectorDir string,
+	sectorCacheRootDir string,
 	maxNumOpenStagedSectors uint8,
 ) (unsafe.Pointer, error) {
 	defer elapsed("InitSectorBuilder")()
@@ -270,6 +270,9 @@ func InitSectorBuilder(
 	cSealedSectorDir := C.CString(sealedSectorDir)
 	defer C.free(unsafe.Pointer(cSealedSectorDir))
 
+	cSectorCacheRootDir := C.CString(sectorCacheRootDir)
+	defer C.free(unsafe.Pointer(cSectorCacheRootDir))
+
 	class, err := cSectorClass(sectorSize, poRepProofPartitions)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get sector class")
@@ -282,6 +285,7 @@ func InitSectorBuilder(
 		(*[32]C.uint8_t)(proverIDCBytes),
 		cSealedSectorDir,
 		cStagedSectorDir,
+		cSectorCacheRootDir,
 		C.uint8_t(maxNumOpenStagedSectors),
 	)
 	defer C.sector_builder_ffi_destroy_init_sector_builder_response(resPtr)

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -41,7 +41,10 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	stagedSectorDir := requireTempDirPath(t)
 	defer require.NoError(t, os.Remove(stagedSectorDir))
 
-	ptr, err := sb.InitSectorBuilder(1024, 2, 1, 0, metadataDir, proverID, sealedSectorDir, stagedSectorDir, 1)
+	sectorCacheRootDir := requireTempDirPath(t)
+	defer require.NoError(t, os.Remove(sectorCacheRootDir))
+
+	ptr, err := sb.InitSectorBuilder(1024, 2, 0, metadataDir, proverID, sealedSectorDir, stagedSectorDir, sectorCacheRootDir, 1)
 	require.NoError(t, err)
 	defer sb.DestroySectorBuilder(ptr)
 


### PR DESCRIPTION
Interactive PoRep will split the existing seal operation into a two-step flow. In the first step, the pre-commit operation will persist some artifacts to a per-sector directory (which is a subdirectory of the sector cache root-dir) for the commit operation to load. As such, the sector builder should be provided a path to a directory into which it can create these per-sector cache directories.