### PR TITLE
fix(paramcache): install from correct branch + disable test run with Darwin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - restore_parameter_cache
       - obtain_filecoin_parameters
       - save_parameter_cache
-      - test_project
+      - build_and_run_tests
   build_and_test_darwin:
     macos:
       xcode: "10.0.0"
@@ -60,7 +60,7 @@ jobs:
       - restore_parameter_cache
       - obtain_filecoin_parameters
       - save_parameter_cache
-      - test_project
+      - build_and_compile_tests
 
 workflows:
   version: 2
@@ -107,12 +107,17 @@ commands:
       - run:
           name: Lint project
           command: go run github.com/golangci/golangci-lint/cmd/golangci-lint run
-  test_project:
+  build_and_run_tests:
     steps:
       - run:
           name: Test project
           command: RUST_LOG=info go test -p 1 -timeout 60m
           no_output_timeout: 60m
+  build_and_compile_tests:
+    steps:
+      - run:
+          name: Build project and tests, but don't actually run the tests (used to verify that build/link works with Darwin)
+          command: RUST_LOG=info go test -run=^$
   restore_parameter_cache:
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ commands:
           name: Ensure paramcache is installed to project root
           command: |
             test -f ./paramcache \
-              || (rustup run --install nightly cargo install filecoin-proofs --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch="feat/election-post" --bin=paramcache --root=./ \
+              || (rustup run --install nightly cargo install filecoin-proofs --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master --bin=paramcache --root=./ \
                 && mv ./bin/paramcache ./paramcache)
   lint_project:
     steps:


### PR DESCRIPTION
## Why does this PR exist?

A previous PR (which I reviewed) installed paramcache from a non-master branch.

## What's in this PR?

This changeset points the `cargo install` command at the `master` branch of rust-fil-proofs. It also  modifies the CircleCI config such that it no longer runs the tests with Darwin, but rather builds the project and tests and ensure linking works with the static lib.