### PR TITLE
change to build source of deps submodule instead of dowloading prebui…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: $(DEPS)
 $(DEPS): .install-rust-fil-sector-builder  ;
 
 .install-rust-fil-sector-builder: rust-fil-sector-builder
-	./install-rust-fil-sector-builder
+	./install-rust-fil-sector-builder build
 	@touch $@
 
 

--- a/install-rust-fil-sector-builder
+++ b/install-rust-fil-sector-builder
@@ -9,7 +9,7 @@ subm_dir="rust-fil-sector-builder"
 
 git submodule update --init --recursive $subm_dir
 
-if download_release_tarball tarball_path "${subm_dir}"; then
+download() {
     tmp_dir=$(mktemp -d)
     tar -C "$tmp_dir" -xzf "$tarball_path"
 
@@ -18,8 +18,9 @@ if download_release_tarball tarball_path "${subm_dir}"; then
     cp "${tmp_dir}/lib/pkgconfig/sector_builder_ffi.pc" .
 
     cp "${tmp_dir}/bin/paramcache" .
-else
-    (>&2 echo "failed to find or obtain precompiled assets for ${subm_dir} - falling back to local build")
+}
+
+build() {
     build_from_source "${subm_dir}"
 
     mkdir -p include
@@ -45,4 +46,20 @@ else
     fi
 
     (>&2 echo "WARNING: paramcache was not installed - you may wish to 'cargo install' it")
+}
+
+if [ $# = 0 ]; then
+    if download_release_tarball tarball_path "${subm_dir}"; then
+	download
+    else
+	(>&2 echo "failed to find or obtain precompiled assets for ${subm_dir} - falling back to local build")
+	build
+    fi
+elif [ $1 == "build" ]; then
+    build
+elif [ $1 == "download" ]; then
+    download
+else
+    (>&2 echo "usage $0 [build|download]")
+    exit 1
 fi


### PR DESCRIPTION
1. change the bash build script into two options regarding dependent rust-fil-sector-builder submodule: build from source(build) or download prebuilt package
2. change default option in Makefile to 'build from source'  