### PR TITLE
fix(names): fix transposed Public/Sector/Private

### DIFF
--- a/bindings.go
+++ b/bindings.go
@@ -33,13 +33,13 @@ func elapsed(what string) func() {
 // SortedPublicSectorInfo is a slice of PublicSectorInfo sorted
 // (lexicographically, ascending) by replica commitment (CommR).
 type SortedPublicSectorInfo struct {
-	f []SectorPublicInfo
+	f []PublicSectorInfo
 }
 
 // SortedPrivateSectorInfo is a slice of PrivateSectorInfo sorted
 // (lexicographically, ascending) by replica commitment (CommR).
 type SortedPrivateSectorInfo struct {
-	f []SectorPrivateInfo
+	f []PrivateSectorInfo
 }
 
 // SealTicket is required for the first step of Interactive PoRep.
@@ -61,8 +61,8 @@ type Candidate struct {
 	SectorChallengeIndex uint64
 }
 
-// NewSortedSectorPublicInfo returns a SortedPublicSectorInfo
-func NewSortedSectorPublicInfo(sectorInfo ...SectorPublicInfo) SortedPublicSectorInfo {
+// NewSortedPublicSectorInfo returns a SortedPublicSectorInfo
+func NewSortedPublicSectorInfo(sectorInfo ...PublicSectorInfo) SortedPublicSectorInfo {
 	fn := func(i, j int) bool {
 		return bytes.Compare(sectorInfo[i].CommR[:], sectorInfo[j].CommR[:]) == -1
 	}
@@ -74,8 +74,8 @@ func NewSortedSectorPublicInfo(sectorInfo ...SectorPublicInfo) SortedPublicSecto
 	}
 }
 
-// Values returns the sorted SectorPublicInfo as a slice
-func (s *SortedPublicSectorInfo) Values() []SectorPublicInfo {
+// Values returns the sorted PublicSectorInfo as a slice
+func (s *SortedPublicSectorInfo) Values() []PublicSectorInfo {
 	return s.f
 }
 
@@ -86,20 +86,20 @@ func (s SortedPublicSectorInfo) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON parses the JSON-encoded byte slice and stores the result in the
 // value pointed to by s.f. Note that this method allows for construction of a
-// SortedPublicSectorInfo which violates its invariant (that its SectorPublicInfo are sorted
+// SortedPublicSectorInfo which violates its invariant (that its PublicSectorInfo are sorted
 // in some defined way). Callers should take care to never provide a byte slice
 // which would violate this invariant.
 func (s *SortedPublicSectorInfo) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, &s.f)
 }
 
-type SectorPublicInfo struct {
+type PublicSectorInfo struct {
 	SectorID uint64
 	CommR    [CommitmentBytesLen]byte
 }
 
-// NewSortedSectorPrivateInfo returns a SortedPrivateSectorInfo
-func NewSortedSectorPrivateInfo(sectorInfo ...SectorPrivateInfo) SortedPrivateSectorInfo {
+// NewSortedPrivateSectorInfo returns a SortedPrivateSectorInfo
+func NewSortedPrivateSectorInfo(sectorInfo ...PrivateSectorInfo) SortedPrivateSectorInfo {
 	fn := func(i, j int) bool {
 		return bytes.Compare(sectorInfo[i].CommR[:], sectorInfo[j].CommR[:]) == -1
 	}
@@ -111,8 +111,8 @@ func NewSortedSectorPrivateInfo(sectorInfo ...SectorPrivateInfo) SortedPrivateSe
 	}
 }
 
-// Values returns the sorted SectorPrivateInfo as a slice
-func (s *SortedPrivateSectorInfo) Values() []SectorPrivateInfo {
+// Values returns the sorted PrivateSectorInfo as a slice
+func (s *SortedPrivateSectorInfo) Values() []PrivateSectorInfo {
 	return s.f
 }
 
@@ -125,7 +125,7 @@ func (s *SortedPrivateSectorInfo) UnmarshalJSON(b []byte) error {
 	return json.Unmarshal(b, &s.f)
 }
 
-type SectorPrivateInfo struct {
+type PrivateSectorInfo struct {
 	SectorID         uint64
 	CommR            [CommitmentBytesLen]byte
 	CacheDirPath     string

--- a/bindings_test.go
+++ b/bindings_test.go
@@ -172,8 +172,8 @@ func TestSectorBuilderLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, isValid)
 
-	// enforces sort ordering of SectorPublicInfo tuples
-	sectorInfo := sb.NewSortedSectorPublicInfo(sb.SectorPublicInfo{
+	// enforces sort ordering of PublicSectorInfo tuples
+	sectorInfo := sb.NewSortedPublicSectorInfo(sb.PublicSectorInfo{
 		SectorID: statusA.SectorID,
 		CommR:    statusA.CommR,
 	})
@@ -351,14 +351,14 @@ func TestImportSector(t *testing.T) {
 
 	// generate a PoSt over the proving set before importing, just to exercise
 	// the new API
-	privateInfo := sb.NewSortedSectorPrivateInfo(sb.SectorPrivateInfo{
+	privateInfo := sb.NewSortedPrivateSectorInfo(sb.PrivateSectorInfo{
 		SectorID:         sectorID,
 		CommR:            output.CommR,
 		CacheDirPath:     sectorCacheDirPath,
 		SealedSectorPath: sealedSectorFile.Name(),
 	})
 
-	publicInfo := sb.NewSortedSectorPublicInfo(sb.SectorPublicInfo{
+	publicInfo := sb.NewSortedPublicSectorInfo(sb.PublicSectorInfo{
 		SectorID: sectorID,
 		CommR:    output.CommR,
 	})
@@ -413,9 +413,9 @@ func TestImportSector(t *testing.T) {
 
 func TestJsonMarshalSymmetry(t *testing.T) {
 	for i := 0; i < 100; i++ {
-		xs := make([]sb.SectorPublicInfo, 10)
+		xs := make([]sb.PublicSectorInfo, 10)
 		for j := 0; j < 10; j++ {
-			var x sb.SectorPublicInfo
+			var x sb.PublicSectorInfo
 			_, err := io.ReadFull(rand.Reader, x.CommR[:])
 			require.NoError(t, err)
 
@@ -424,7 +424,7 @@ func TestJsonMarshalSymmetry(t *testing.T) {
 			x.SectorID = n.Uint64()
 			xs[j] = x
 		}
-		toSerialize := sb.NewSortedSectorPublicInfo(xs...)
+		toSerialize := sb.NewSortedPublicSectorInfo(xs...)
 
 		serialized, err := toSerialize.MarshalJSON()
 		require.NoError(t, err)

--- a/transforms.go
+++ b/transforms.go
@@ -106,7 +106,7 @@ func cCandidates(src []Candidate) (*C.sector_builder_ffi_FFICandidate, C.size_t)
 	return (*C.sector_builder_ffi_FFICandidate)(cCandidates), srcCSizeT
 }
 
-func cPrivateReplicaInfos(src []SectorPrivateInfo) (*C.sector_builder_ffi_FFIPrivateReplicaInfo, C.size_t) {
+func cPrivateReplicaInfos(src []PrivateSectorInfo) (*C.sector_builder_ffi_FFIPrivateReplicaInfo, C.size_t) {
 	srcCSizeT := C.size_t(len(src))
 
 	cPrivateReplicas := C.malloc(srcCSizeT * C.sizeof_sector_builder_ffi_FFIPrivateReplicaInfo)


### PR DESCRIPTION
## Why does this PR exist?

The repo contains a typeo; it is not consistent in its ordering of `Public`/`Private` and `Sector`. See also [this thread](https://filecoinproject.slack.com/archives/CEGB67XJ8/p1574641567229200) from @whyrusleeping.

## What's in this PR?

This changeset standardizes that term-ordering in the types.