### PR TITLE
fix: build Rust parts from source if available 

### DIFF
--- a/install-rust-fil-sector-builder
+++ b/install-rust-fil-sector-builder
@@ -28,7 +28,6 @@ if [ -z "$(ls -A $subm_dir)" ]; then
 fi
 
 # Directory is not empty, hence compiling whatever source is in there
-(>&2 echo "building ${subm_dir} from source")
 build_from_source "${subm_dir}"
 
 mkdir -p include

--- a/install-rust-fil-sector-builder
+++ b/install-rust-fil-sector-builder
@@ -7,42 +7,50 @@ source "install-shared.bash"
 
 subm_dir="rust-fil-sector-builder"
 
-git submodule update --init --recursive $subm_dir
+# If the directory is empty, try to download the pre-built tarballs or
+# checkout the source code as fallback
+if [ -z "$(ls -A $subm_dir)" ]; then
+    if download_release_tarball tarball_path "${subm_dir}"; then
+        tmp_dir=$(mktemp -d)
+        tar -C "$tmp_dir" -xzf "$tarball_path"
 
-if download_release_tarball tarball_path "${subm_dir}"; then
-    tmp_dir=$(mktemp -d)
-    tar -C "$tmp_dir" -xzf "$tarball_path"
+        cp "${tmp_dir}/include/sector_builder_ffi.h" .
+        cp "${tmp_dir}/lib/libsector_builder_ffi.a" .
+        cp "${tmp_dir}/lib/pkgconfig/sector_builder_ffi.pc" .
 
-    cp "${tmp_dir}/include/sector_builder_ffi.h" .
-    cp "${tmp_dir}/lib/libsector_builder_ffi.a" .
-    cp "${tmp_dir}/lib/pkgconfig/sector_builder_ffi.pc" .
+        cp "${tmp_dir}/bin/paramcache" .
 
-    cp "${tmp_dir}/bin/paramcache" .
-else
-    (>&2 echo "failed to find or obtain precompiled assets for ${subm_dir} - falling back to local build")
-    build_from_source "${subm_dir}"
-
-    mkdir -p include
-    mkdir -p lib/pkgconfig
-
-    find "${subm_dir}/target/release" -type f -name sector_builder_ffi.h -exec cp -- "{}" . \;
-    find "${subm_dir}/target/release" -type f -name libsector_builder_ffi.a -exec cp -- "{}" . \;
-    find "${subm_dir}" -type f -name sector_builder_ffi.pc -exec cp -- "{}" . \;
-
-    if [[ ! -f "./sector_builder_ffi.h" ]]; then
-        (>&2 echo "failed to install sector_builder_ffi.h")
-        exit 1
+        exit 0
+    else
+        (>&2 echo "failed to find or obtain precompiled assets for ${subm_dir} - falling back to local build")
+        git submodule update --init --recursive $subm_dir
     fi
-
-    if [[ ! -f "./libsector_builder_ffi.a" ]]; then
-        (>&2 echo "failed to install libsector_builder_ffi.a")
-        exit 1
-    fi
-
-    if [[ ! -f "./sector_builder_ffi.pc" ]]; then
-        (>&2 echo "failed to install sector_builder_ffi.pc")
-        exit 1
-    fi
-
-    (>&2 echo "WARNING: paramcache was not installed - you may wish to 'cargo install' it")
 fi
+
+# Directory is not empty, hence compiling whatever source is in there
+(>&2 echo "building ${subm_dir} from source")
+build_from_source "${subm_dir}"
+
+mkdir -p include
+mkdir -p lib/pkgconfig
+
+find "${subm_dir}/target/release" -type f -name sector_builder_ffi.h -exec cp -- "{}" . \;
+find "${subm_dir}/target/release" -type f -name libsector_builder_ffi.a -exec cp -- "{}" . \;
+find "${subm_dir}" -type f -name sector_builder_ffi.pc -exec cp -- "{}" . \;
+
+if [[ ! -f "./sector_builder_ffi.h" ]]; then
+    (>&2 echo "failed to install sector_builder_ffi.h")
+    exit 1
+fi
+
+if [[ ! -f "./libsector_builder_ffi.a" ]]; then
+    (>&2 echo "failed to install libsector_builder_ffi.a")
+    exit 1
+fi
+
+if [[ ! -f "./sector_builder_ffi.pc" ]]; then
+    (>&2 echo "failed to install sector_builder_ffi.pc")
+    exit 1
+fi
+
+(>&2 echo "WARNING: paramcache was not installed - you may wish to 'cargo install' it")

--- a/install-shared.bash
+++ b/install-shared.bash
@@ -44,10 +44,10 @@ download_release_tarball() {
 
 build_from_source() {
     __submodule_path=$1
-    __submodule_sha1=$(git rev-parse @:"${__submodule_path}")
+    __submodule_sha1=$(cd ${__submodule_path} && git rev-parse @)
     __submodule_sha1_truncated="${__submodule_sha1:0:16}"
 
-    echo "building from source @ ${__submodule_sha1_truncated}"
+    echo "building ${__submodule_path} from source @ ${__submodule_sha1_truncated}"
 
     if ! [ -x "$(command -v cargo)" ]; then
         (>&2 echo 'Error: cargo is not installed.')


### PR DESCRIPTION
Old workflow:

 - Checkout submodule
 - Try to download precompiled assets
   - If downloading fails, compile the checked out submoduke

New workflow:

 - Download precompiled assets if submodule directory is empty
   - If download fails checkout the submodule
   - Compile the submodule
 - If the submodule directory is not empty, compile what is in there

The new workflow makes it easy to have a custom version of the submodule
checked out in the directory and getting everything built correctly.

Best reviewed [without whitespace changes](https://github.com/filecoin-project/go-sectorbuilder/pull/58/files?w=1).