### PR TITLE
update to v22 parameters, versioned proofs API, and two-phase pre-commit and commit

### DIFF
--- a/files.go
+++ b/files.go
@@ -53,6 +53,9 @@ func (sb *SectorBuilder) TrimCache(ctx context.Context, sectorNum abi.SectorNumb
 		if strings.HasSuffix(file.Name(), "-data-tree-r-last.dat") { // Want to keep
 			continue
 		}
+		if strings.HasSuffix(file.Name(), "-data-tree-d.dat") { // Want to keep
+			continue
+		}
 
 		if err := os.Remove(filepath.Join(string(dir), file.Name())); err != nil {
 			return xerrors.Errorf("rm %s: %w", file.Name(), err)

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20191219131535-bb699517a590
 	github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5
+	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878
 	github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
+	github.com/ipfs/go-cid v0.0.5
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-ipld-format v0.0.2 // indirect
 	github.com/ipfs/go-log v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20191219131535-bb699517a590
 	github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5
 	github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878
-	github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf
+	github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/ipfs/go-datastore v0.1.1
 	github.com/ipfs/go-ipld-format v0.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.0.2
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/otiai10/copy v1.0.2
+	github.com/pkg/errors v0.9.1
 	github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a // indirect
 	github.com/smartystreets/assertions v1.0.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,10 @@ module github.com/filecoin-project/go-sectorbuilder
 go 1.13
 
 require (
-	github.com/fatih/color v1.7.0 // indirect
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20191219131535-bb699517a590
 	github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878
+	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
 	github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/ipfs/go-cid v0.0.5
@@ -15,7 +14,6 @@ require (
 	github.com/ipfs/go-ipld-format v0.0.2 // indirect
 	github.com/ipfs/go-log v1.0.0
 	github.com/ipfs/go-log/v2 v2.0.2
-	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/otiai10/copy v1.0.2
 	github.com/polydawn/refmt v0.0.0-20190809202753-05966cbd336a // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,10 +29,12 @@ github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
+github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
+github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878 h1:YicJT9xhPzZ1SBGiJFNUCkfwqK/G9vFyY1ytKBSjNJA=
 github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878/go.mod h1:40kI2Gv16mwcRsHptI3OAV4nlOEU7wVDc4RgMylNFjU=
-github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf h1:fbxBG12yrxilPFV1EG2lYqpUyAlRZWkvtqjk2svSeXY=
-github.com/filecoin-project/specs-actors v0.0.0-20200210130641-2d1fbd8672cf/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
+github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341 h1:mDfwS/9ck3lQH9+xZfDTj6kpp12g77q0dHT2+94QYEI=
+github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
@@ -63,6 +65,8 @@ github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUP
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.4 h1:UlfXKrZx1DjZoBhQHmNHLC1fK1dUJDN20Y28A7s+gJ8=
 github.com/ipfs/go-cid v0.0.4/go.mod h1:4LLaPOQwmk5z9LBgQnpkivrx8BJjUyGwTXCd5Xfj6+M=
+github.com/ipfs/go-cid v0.0.5 h1:o0Ix8e/ql7Zb5UVUJEUfjsWCIY8t48++9lR8qi6oiJU=
+github.com/ipfs/go-cid v0.0.5/go.mod h1:plgt+Y5MnOey4vO4UlUazGqdbEXuFYitED67FexhXog=
 github.com/ipfs/go-datastore v0.1.1 h1:F4k0TkTAZGLFzBOrVKDAvch6JZtuN4NHkfdcEZL50aI=
 github.com/ipfs/go-datastore v0.1.1/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
 github.com/ipfs/go-hamt-ipld v0.0.15-0.20200131012125-dd88a59d3f2e/go.mod h1:9aQJu/i/TaRDW6jqB5U217dLIDopn50wxLdHXM2CTfE=
@@ -140,9 +144,13 @@ github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKT
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
 github.com/multiformats/go-multihash v0.0.10 h1:lMoNbh2Ssd9PUF74Nz008KGzGPlfeV6wH3rit5IIGCM=
 github.com/multiformats/go-multihash v0.0.10/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=
+github.com/multiformats/go-multihash v0.0.13 h1:06x+mk/zj1FoMsgNejLpy6QTvJqlSt/BhLEy87zidlc=
+github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-varint v0.0.1/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.2 h1:6sUvyh2YHpJCb8RZ6eYzj6iJQ4+chWYmyIHxszqlPTA=
 github.com/multiformats/go-varint v0.0.2/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
+github.com/multiformats/go-varint v0.0.5 h1:XVZwSo04Cs3j/jS0uAEPpT3JY6DzMcVLLoWOSnCxOjg=
+github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -25,7 +25,6 @@ github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMX
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
-github.com/filecoin-project/go-paramfetch v0.0.1 h1:gV7bs5YaqlgpGFMiLxInGK2L1FyCXUE0rimz4L7ghoE=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 h1:eYxi6vI5CyeXD15X1bB3bledDXbqKxqf0wQzTLgwYwA=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
 github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341 h1:mDfwS/9ck3lQH9+xZfDTj6kpp12g77q0dHT2+94QYEI=

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,7 @@ github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMX
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
+github.com/filecoin-project/go-paramfetch v0.0.1 h1:gV7bs5YaqlgpGFMiLxInGK2L1FyCXUE0rimz4L7ghoE=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 h1:eYxi6vI5CyeXD15X1bB3bledDXbqKxqf0wQzTLgwYwA=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
 github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341 h1:mDfwS/9ck3lQH9+xZfDTj6kpp12g77q0dHT2+94QYEI=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
-github.com/GeertJohan/go.rice v1.0.0 h1:KkI6O9uMaQU3VEKaj01ulavtF7o1fWT7+pk/4voiMLQ=
-github.com/GeertJohan/go.rice v1.0.0/go.mod h1:eH6gbSOAUv07dQuZVnBmoDP8mgsM1rtixis4Tib9if0=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
@@ -16,14 +12,12 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
-github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=
-github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
-github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.8.0 h1:5bzFgL+oy7JITMTxUPJ00n7VxmYd/PdMp5mHFX40/RY=
+github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGjnw8=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
@@ -31,8 +25,8 @@ github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMX
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1:yvQJCW9mmi9zy+51xA01Ea2X7/dL7r8eKDPuGUjRmbo=
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
-github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878 h1:YicJT9xhPzZ1SBGiJFNUCkfwqK/G9vFyY1ytKBSjNJA=
-github.com/filecoin-project/go-paramfetch v0.0.0-20200102181131-b20d579f2878/go.mod h1:40kI2Gv16mwcRsHptI3OAV4nlOEU7wVDc4RgMylNFjU=
+github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 h1:eYxi6vI5CyeXD15X1bB3bledDXbqKxqf0wQzTLgwYwA=
+github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
 github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341 h1:mDfwS/9ck3lQH9+xZfDTj6kpp12g77q0dHT2+94QYEI=
 github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -114,8 +108,9 @@ github.com/libp2p/go-openssl v0.0.4/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
-github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
+github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -151,7 +146,6 @@ github.com/multiformats/go-varint v0.0.2 h1:6sUvyh2YHpJCb8RZ6eYzj6iJQ4+chWYmyIHx
 github.com/multiformats/go-varint v0.0.2/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.5 h1:XVZwSo04Cs3j/jS0uAEPpT3JY6DzMcVLLoWOSnCxOjg=
 github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
-github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -193,8 +187,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
-github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830 h1:8kxMKmKzXXL4Ru1nyhvdms/JjWt+3YLpvRb/bAjO/y0=
 github.com/warpfork/go-wish v0.0.0-20190328234359-8b3e70f8e830/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
@@ -246,6 +238,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20180202135801-37707fdb30a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/interface.go
+++ b/interface.go
@@ -5,10 +5,9 @@ import (
 	"io"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/ipfs/go-cid"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
 
 	"github.com/filecoin-project/go-sectorbuilder/fs"
 )

--- a/interface.go
+++ b/interface.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"io"
 
+	ffi "github.com/filecoin-project/filecoin-ffi"
+	"github.com/ipfs/go-cid"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 
@@ -13,22 +16,22 @@ import (
 type Interface interface {
 	RateLimit() func()
 
-	AddPiece(context.Context, abi.UnpaddedPieceSize, abi.SectorNumber, io.Reader, []abi.UnpaddedPieceSize) (PublicPieceInfo, error)
+	AddPiece(context.Context, abi.UnpaddedPieceSize, abi.SectorNumber, io.Reader, []abi.UnpaddedPieceSize) (abi.PieceInfo, error)
 	SectorSize() abi.SectorSize
 	AcquireSectorNumber() (abi.SectorNumber, error)
-	Scrub(SortedPublicSectorInfo) []*Fault
+	Scrub([]abi.SectorNumber) []*Fault
 
-	GenerateEPostCandidates(sectorInfo SortedPublicSectorInfo, challengeSeed [CommLen]byte, faults []abi.SectorNumber) ([]EPostCandidate, error)
-	GenerateFallbackPoSt(SortedPublicSectorInfo, [CommLen]byte, []abi.SectorNumber) ([]EPostCandidate, []byte, error)
-	ComputeElectionPoSt(sectorInfo SortedPublicSectorInfo, challengeSeed []byte, winners []EPostCandidate) ([]byte, error)
+	GenerateEPostCandidates(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, error)
+	GenerateFallbackPoSt(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, []byte, error)
+	ComputeElectionPoSt(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, winners []abi.PoStCandidate) ([]byte, error)
 
-	SealPreCommit(context.Context, abi.SectorNumber, SealTicket, []PublicPieceInfo) (RawSealPreCommitOutput, error)
-	SealCommit(context.Context, abi.SectorNumber, SealTicket, SealSeed, []PublicPieceInfo, RawSealPreCommitOutput) ([]byte, error)
+	SealPreCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, pieces []abi.PieceInfo) (sealedCID cid.Cid, unsealedCID cid.Cid, err error)
+	SealCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof abi.SealProof, err error)
 	// FinalizeSector cleans up cache, and moves it to storage filesystem
 	FinalizeSector(context.Context, abi.SectorNumber) error
 	DropStaged(context.Context, abi.SectorNumber) error
 
-	ReadPieceFromSealedSector(ctx context.Context, sectorNum abi.SectorNumber, offset UnpaddedByteIndex, size abi.UnpaddedPieceSize, ticket []byte, commD []byte) (io.ReadCloser, error)
+	ReadPieceFromSealedSector(context.Context, abi.SectorNumber, UnpaddedByteIndex, abi.UnpaddedPieceSize, abi.SealRandomness, cid.Cid) (io.ReadCloser, error)
 
 	SectorPath(typ fs.DataType, sectorNum abi.SectorNumber) (fs.SectorPath, error)
 	AllocSectorPath(typ fs.DataType, sectorNum abi.SectorNumber, cache bool) (fs.SectorPath, error)
@@ -42,7 +45,7 @@ type Interface interface {
 type UnpaddedByteIndex uint64
 
 type Verifier interface {
-	VerifyElectionPost(ctx context.Context, sectorSize abi.SectorSize, sectorInfo SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []EPostCandidate, proverID address.Address) (bool, error)
-	VerifyFallbackPost(ctx context.Context, sectorSize abi.SectorSize, sectorInfo SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []EPostCandidate, proverID address.Address, faults uint64) (bool, error)
-	VerifySeal(sectorSize abi.SectorSize, commR, commD []byte, proverID address.Address, ticket []byte, seed []byte, sectorNum abi.SectorNumber, proof []byte) (bool, error)
+	VerifySeal(proofType abi.RegisteredProof, sealedCID, unsealedCID cid.Cid, prover address.Address, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, sectorNum abi.SectorNumber, proof abi.SealProof) (bool, error)
+	VerifyElectionPost(ctx context.Context, sectorInfo ffi.SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []abi.PoStCandidate, prover address.Address) (bool, error)
+	VerifyFallbackPost(ctx context.Context, sectorInfo ffi.SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []abi.PoStCandidate, prover address.Address, faults uint64) (bool, error)
 }

--- a/mock.go
+++ b/mock.go
@@ -1,8 +1,6 @@
 package sectorbuilder
 
 import (
-	"fmt"
-
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-datastore"
@@ -10,24 +8,10 @@ import (
 	"github.com/filecoin-project/go-sectorbuilder/fs"
 )
 
-func TempSectorbuilderDir(paths []fs.PathConfig, sectorSize abi.SectorSize, ds datastore.Batching) (*SectorBuilder, error) {
+func TempSectorbuilderDir(paths []fs.PathConfig, sealProofType, postProofType abi.RegisteredProof, ds datastore.Batching) (*SectorBuilder, error) {
 	addr, err := address.NewFromString("t0123")
 	if err != nil {
 		return nil, err
-	}
-
-	var sealProofType abi.RegisteredProof
-	var postProofType abi.RegisteredProof
-
-	switch n := uint64(sectorSize); n {
-	case 1024:
-		sealProofType = abi.RegisteredProof_StackedDRG1KiBSeal
-		postProofType = abi.RegisteredProof_StackedDRG1KiBPoSt
-	case 1048576:
-		sealProofType = abi.RegisteredProof_StackedDRG16MiBSeal
-		postProofType = abi.RegisteredProof_StackedDRG16MiBPoSt
-	default:
-		panic(fmt.Sprintf("mock sector builder does not support sector size: %+v", sectorSize))
 	}
 
 	sb, err := New(&Config{

--- a/mock.go
+++ b/mock.go
@@ -1,6 +1,8 @@
 package sectorbuilder
 
 import (
+	"fmt"
+
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-datastore"
@@ -14,8 +16,23 @@ func TempSectorbuilderDir(paths []fs.PathConfig, sectorSize abi.SectorSize, ds d
 		return nil, err
 	}
 
+	var sealProofType abi.RegisteredProof
+	var postProofType abi.RegisteredProof
+
+	switch n := uint64(sectorSize); n {
+	case 1024:
+		sealProofType = abi.RegisteredProof_StackedDRG1KiBSeal
+		postProofType = abi.RegisteredProof_StackedDRG1KiBPoSt
+	case 1048576:
+		sealProofType = abi.RegisteredProof_StackedDRG16MiBSeal
+		postProofType = abi.RegisteredProof_StackedDRG16MiBPoSt
+	default:
+		panic(fmt.Sprintf("mock sector builder does not support sector size: %+v", sectorSize))
+	}
+
 	sb, err := New(&Config{
-		SectorSize: sectorSize,
+		SealProofType: sealProofType,
+		PoStProofType: postProofType,
 
 		Paths: paths,
 

--- a/parameters.json
+++ b/parameters.json
@@ -1,0 +1,102 @@
+{
+  "v22-proof-of-spacetime-election-PoseidonHasher-0b0b9781bcb153efbb3cab4be3a792c4f555d4ab6f8dd62b27e1dcad08a34f22.params": {
+    "cid": "QmQ6dHcrtuXGpmsbZH72W223b3hdSKGtR9oaSMwsM9NkzD",
+    "digest": "a0799a458f44626bac7df3093b0294e4",
+    "sector_size": 34359738368
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-0b0b9781bcb153efbb3cab4be3a792c4f555d4ab6f8dd62b27e1dcad08a34f22.vk": {
+    "cid": "QmS5Vxn9uzZfyGoZJHSj3ZDdEeRd8nEczqJR5CsQd7pSJG",
+    "digest": "ce4a1b197b23d0aa10315dbf9bc522a0",
+    "sector_size": 34359738368
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-0ffac504e6feaec47f7baf3eb1b451690c0aa7e726b749cf030819f947d81bf7.params": {
+    "cid": "QmS8M8iXyAHApXBLdJ6st9PJhw36wHZtQ3dn2q47ZXuvWN",
+    "digest": "385b6a6e2748e56598685413bf3aaede",
+    "sector_size": 1024
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-0ffac504e6feaec47f7baf3eb1b451690c0aa7e726b749cf030819f947d81bf7.vk": {
+    "cid": "QmYSidQXSbuftzNnMiXsGV1hLAtsB94EPBHzH1LvXdWgn7",
+    "digest": "938abd0f3416c6ae1e8dd21fa4d92b4e",
+    "sector_size": 1024
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-9b5673a5c0df861151c2b8087fe4f0d8657558d07ce768b7067dab2eea76dad4.params": {
+    "cid": "QmX957ftCjZehyNSVUFLi6kqF7nsSh2gf2kNVgTekCA5K4",
+    "digest": "9b47a0e0da9350be2c5627d5b5c55ba1",
+    "sector_size": 16777216
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-9b5673a5c0df861151c2b8087fe4f0d8657558d07ce768b7067dab2eea76dad4.vk": {
+    "cid": "QmSTTzD5jvqRzBGj67mzjj75WfAoG9ntkwq28u2ckh9odA",
+    "digest": "dee344a21099eb6487df78598ba59640",
+    "sector_size": 16777216
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-cd7aba426e27fc8e65abd777be0908fb536aa550c09a00ebae7596206f83b107.params": {
+    "cid": "QmWaQ6bupbWM76ALbb61SkFmsKRGV9Rek9Y2ieGsJEyCgT",
+    "digest": "f91e462f2d21bd9ae4b21196b784f081",
+    "sector_size": 1073741824
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-cd7aba426e27fc8e65abd777be0908fb536aa550c09a00ebae7596206f83b107.vk": {
+    "cid": "QmYxJeX37TLBjYz9kEKNBtwrM3SqRXGavHMWTCB8P2bhoH",
+    "digest": "c6467c4f0d70e0fbb23d705d1f5f0245",
+    "sector_size": 1073741824
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-fe3e586b9bc36865d0fb0da9fd8d336b5ef10a0c1abf2a887ffca440b0cfe069.params": {
+    "cid": "QmbhQPh8Sahx3iW6pvZPj3EDSVjGMXmxwMv5TD8H4BFg3E",
+    "digest": "d6ffbfaf96b34ed8549db6d81c5e3efa",
+    "sector_size": 268435456
+  },
+  "v22-proof-of-spacetime-election-PoseidonHasher-fe3e586b9bc36865d0fb0da9fd8d336b5ef10a0c1abf2a887ffca440b0cfe069.vk": {
+    "cid": "Qmc7yEwQG6qigYNMWrJBRfMwgaMoUW3XVdanPdnKCaeLiQ",
+    "digest": "2965f17ecc9ec6c9f5a27a4f4940b55c",
+    "sector_size": 268435456
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-2824c92b9812d2ef306376a6c96b6edab9247472bccf6485a64b7d6f7e1031cb.params": {
+    "cid": "QmUu5NCkCSwKXpHygPwamy2ZVgaqwUSe4UZUVGcoxxK1rX",
+    "digest": "03f9fbf59d4b028eefe62991244d314c",
+    "sector_size": 268435456
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-2824c92b9812d2ef306376a6c96b6edab9247472bccf6485a64b7d6f7e1031cb.vk": {
+    "cid": "QmSZPeySPfL9HAiakDda9ZRFce8WqVMRANPo6jqrT7Byf7",
+    "digest": "48d7eb2efaf6786a893e40f655907814",
+    "sector_size": 268435456
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-97898c09be471d01d125f93ba4dd8d1a5634e404c1c7d1ea21014d0c8656a29a.params": {
+    "cid": "QmcGxjoa7WU9cphRzRyHJ2aM1EsQdo7ZVPiCPVjbRShpH2",
+    "digest": "f9915452f4547bbb93663cec214626cd",
+    "sector_size": 1073741824
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-97898c09be471d01d125f93ba4dd8d1a5634e404c1c7d1ea21014d0c8656a29a.vk": {
+    "cid": "Qmc9tXAG99A8ykiV5AwXenKTfd2GXtLA6RdWYyhyT9J6c8",
+    "digest": "48c207aa03b9db61ed595b02ff380d80",
+    "sector_size": 1073741824
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-b9678fc0c28dfcec342ca4c7886020d583b16258c9bc93aafad679d09400e401.params": {
+    "cid": "QmUxFUyjutaf4yZwtjij7Gd5oxDqfHpLNVjBXaNLnbHPeB",
+    "digest": "3a648b28e0b2795f58868ef964af8e09",
+    "sector_size": 1024
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-b9678fc0c28dfcec342ca4c7886020d583b16258c9bc93aafad679d09400e401.vk": {
+    "cid": "Qmai7WbNjxW7MC8uQzXKeRBFdGLBSFMXx6m8c1dTiqtsrK",
+    "digest": "200daeec486802fc1310fbb5baad42d5",
+    "sector_size": 1024
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-f4bdecc971c681000d2e56d2e8f40877710978727ff383550bdc6202cdcdd9cd.params": {
+    "cid": "QmWcJUuJHyDZZWfmhq9nLVYAZxxCFozjD8axPYwUpk9HhL",
+    "digest": "337735473a92e4b4d9335180c5463340",
+    "sector_size": 16777216
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-f4bdecc971c681000d2e56d2e8f40877710978727ff383550bdc6202cdcdd9cd.vk": {
+    "cid": "QmUAcZ32NWndqMEuYs5HhULqw9XgbJnEsrSANXjs4YBJys",
+    "digest": "1bd4cddb08b94a1af8c63e7559e27a75",
+    "sector_size": 16777216
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-fc32be6028c2398175466f36fa36810842ae8948fae15c84454af5b61ca99e15.params": {
+    "cid": "QmNVR2z1aT6FQLFtx35AhJ8zyR8hyJyxTbxMx2NvUkDrky",
+    "digest": "41b102d948130449afbce487b16d148f",
+    "sector_size": 34359738368
+  },
+  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-fc32be6028c2398175466f36fa36810842ae8948fae15c84454af5b61ca99e15.vk": {
+    "cid": "QmbPxsRdS7yr6aEHXWDoRvMnvtz9LqTj7DAH4i7AyTetpq",
+    "digest": "70e806d302ee8828faa3b07d2dace2a8",
+    "sector_size": 34359738368
+  }
+}

--- a/remote.go
+++ b/remote.go
@@ -3,6 +3,8 @@ package sectorbuilder
 import (
 	"context"
 
+	"github.com/ipfs/go-cid"
+
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"golang.org/x/xerrors"
 )
@@ -21,12 +23,13 @@ type WorkerTask struct {
 	SectorNum abi.SectorNumber
 
 	// preCommit
-	SealTicket SealTicket
-	Pieces     []PublicPieceInfo
+	SealTicket abi.SealRandomness // Ticket
+	Pieces     []abi.PieceInfo    // (CommP, Size)
 
 	// commit
-	SealSeed SealSeed
-	Rspco    RawSealPreCommitOutput
+	SealSeed    abi.InteractiveSealRandomness // Seed
+	SealedCID   cid.Cid                       // CommR
+	UnsealedCID cid.Cid                       // CommD
 }
 
 type workerCall struct {

--- a/remote.go
+++ b/remote.go
@@ -3,9 +3,8 @@ package sectorbuilder
 import (
 	"context"
 
-	"github.com/ipfs/go-cid"
-
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
 	"golang.org/x/xerrors"
 )
 

--- a/scrub.go
+++ b/scrub.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	sectorbuilder "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"golang.org/x/xerrors"
 
@@ -18,13 +17,13 @@ type Fault struct {
 	Err error
 }
 
-func (sb *SectorBuilder) Scrub(sectorSet sectorbuilder.SortedPublicSectorInfo) []*Fault {
+func (sb *SectorBuilder) Scrub(sectorSet []abi.SectorNumber) []*Fault {
 	var faults []*Fault
 
-	for _, sector := range sectorSet.Values() {
-		err := sb.checkSector(sector.SectorNum)
+	for _, sectorNum := range sectorSet {
+		err := sb.checkSector(sectorNum)
 		if err != nil {
-			faults = append(faults, &Fault{SectorNum: sector.SectorNum, Err: err})
+			faults = append(faults, &Fault{SectorNum: sectorNum, Err: err})
 		}
 	}
 

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -26,7 +26,7 @@ var lastSectorNumKey = datastore.NewKey("/last")
 
 var log = logging.Logger("sectorbuilder")
 
-func ToJSONStruct(sealedCID cid.Cid, unsealedCID cid.Cid) (JsonRSPCO, error) {
+func NewJsonRSPCO(sealedCID cid.Cid, unsealedCID cid.Cid) (JsonRSPCO, error) {
 	commR, err := commcid.CIDToReplicaCommitmentV1(sealedCID)
 	if err != nil {
 		return JsonRSPCO{}, err

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -300,10 +300,11 @@ func (sb *SectorBuilder) pubSectorToPriv(sectorInfo ffi.SortedPublicSectorInfo, 
 		}
 
 		out = append(out, ffi.PrivateSectorInfo{
-			SectorNum:        s.SectorNum,
-			SealedCID:        s.SealedCID,
 			CacheDirPath:     string(cachePath),
+			PoStProofType:    s.PoStProofType,
+			SealedCID:        s.SealedCID,
 			SealedSectorPath: string(sealedPath),
+			SectorNum:        s.SectorNum,
 		})
 	}
 

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -66,14 +66,6 @@ func New(cfg *Config, ds datastore.Batching) (*SectorBuilder, error) {
 		return nil, xerrors.Errorf("minimum worker threads is %d, specified %d", PoStReservedWorkers, cfg.WorkerThreads)
 	}
 
-	if cfg.SealProofType == abi.RegisteredProof(0) {
-		return nil, xerrors.New("must specify a seal proof type from abi.RegisteredProof")
-	}
-
-	if cfg.PoStProofType == abi.RegisteredProof(0) {
-		return nil, xerrors.New("must specify a PoSt proof type from abi.RegisteredProof")
-	}
-
 	sectorSize, err := sizeFromConfig(*cfg)
 	if err != nil {
 		return nil, err
@@ -136,14 +128,6 @@ func New(cfg *Config, ds datastore.Batching) (*SectorBuilder, error) {
 }
 
 func NewStandalone(cfg *Config) (*SectorBuilder, error) {
-	if cfg.SealProofType == abi.RegisteredProof(0) {
-		return nil, xerrors.New("must specify a seal proof type from abi.RegisteredProof")
-	}
-
-	if cfg.PoStProofType == abi.RegisteredProof(0) {
-		return nil, xerrors.New("must specify a PoSt proof type from abi.RegisteredProof")
-	}
-
 	sectorSize, err := sizeFromConfig(*cfg)
 	if err != nil {
 		return nil, err
@@ -434,6 +418,14 @@ func (sb *SectorBuilder) Stop() {
 }
 
 func sizeFromConfig(cfg Config) (abi.SectorSize, error) {
+	if cfg.SealProofType == abi.RegisteredProof(0) {
+		return abi.SectorSize(0), xerrors.New("must specify a seal proof type from abi.RegisteredProof")
+	}
+
+	if cfg.PoStProofType == abi.RegisteredProof(0) {
+		return abi.SectorSize(0), xerrors.New("must specify a PoSt proof type from abi.RegisteredProof")
+	}
+
 	s1, err := sizeFromProofType(cfg.SealProofType)
 	if err != nil {
 		return abi.SectorSize(0), err

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -26,24 +26,24 @@ var lastSectorNumKey = datastore.NewKey("/last")
 
 var log = logging.Logger("sectorbuilder")
 
-func NewJsonRSPCO(sealedCID cid.Cid, unsealedCID cid.Cid) (JsonRSPCO, error) {
+func NewJsonEncodablePreCommitOutput(sealedCID cid.Cid, unsealedCID cid.Cid) (JsonEncodablePreCommitOutput, error) {
 	commR, err := commcid.CIDToReplicaCommitmentV1(sealedCID)
 	if err != nil {
-		return JsonRSPCO{}, err
+		return JsonEncodablePreCommitOutput{}, err
 	}
 
 	commD, err := commcid.CIDToDataCommitmentV1(unsealedCID)
 	if err != nil {
-		return JsonRSPCO{}, err
+		return JsonEncodablePreCommitOutput{}, err
 	}
 
-	return JsonRSPCO{
+	return JsonEncodablePreCommitOutput{
 		CommD: commD,
 		CommR: commR,
 	}, nil
 }
 
-func (r *JsonRSPCO) ToTuple() (sealedCID cid.Cid, unsealedCID cid.Cid) {
+func (r *JsonEncodablePreCommitOutput) ToTuple() (sealedCID cid.Cid, unsealedCID cid.Cid) {
 	return commcid.ReplicaCommitmentV1ToCID(r.CommR), commcid.DataCommitmentV1ToCID(r.CommD)
 }
 

--- a/sectorbuilder_test.go
+++ b/sectorbuilder_test.go
@@ -13,8 +13,6 @@ import (
 	"time"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-address"
-	commcid "github.com/filecoin-project/go-fil-commcid"
 	paramfetch "github.com/filecoin-project/go-paramfetch"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
@@ -394,44 +392,5 @@ func TestAcquireID(t *testing.T) {
 
 	if err := os.RemoveAll(dir); err != nil {
 		t.Error(err)
-	}
-}
-
-// TestVerifyEmpty tests a certain assumption
-func TestVerifyEmpty(t *testing.T) {
-	cSeed := abi.PoStRandomness{0, 9, 2, 7, 6, 5, 4, 3, 2, 1, 0, 9, 8, 7, 6, 45, 3, 2, 1, 0, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 9}
-	sr := [32]byte{0, 9, 2, 7, 6, 5, 4, 3, 2, 1, 43, 9, 8, 7, 6, 45, 3, 2, 1, 0, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 9}
-	sealedCID := commcid.ReplicaCommitmentV1ToCID(sr[:])
-	t0101, err := address.NewIDAddress(101)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-
-	ok, err := sectorbuilder.ProofVerifier.VerifyFallbackPost(
-		context.TODO(),
-		ffi.NewSortedPublicSectorInfo([]ffi.PublicSectorInfo{
-			{
-				PoStProofType: postProofType,
-				SealedCID:     sealedCID,
-				SectorNum:     abi.SectorNumber(1),
-			},
-			{
-				PoStProofType: postProofType,
-				SealedCID:     sealedCID,
-				SectorNum:     abi.SectorNumber(2),
-			},
-		}...),
-		cSeed,
-		nil, // 0s
-		nil, // 0s
-		t0101,
-		2) //fault everything
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-	if !ok {
-		t.Error("proof not ok")
 	}
 }

--- a/sectorbuilder_test.go
+++ b/sectorbuilder_test.go
@@ -184,7 +184,7 @@ func TestSealAndVerify(t *testing.T) {
 		},
 	}
 
-	sb, err := sectorbuilder.TempSectorbuilderDir(paths, sectorSize, ds)
+	sb, err := sectorbuilder.TempSectorbuilderDir(paths, sealProofType, postProofType, ds)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -224,7 +224,7 @@ func TestSealAndVerify(t *testing.T) {
 	epost := time.Now()
 
 	// Restart sectorbuilder, re-run post
-	sb, err = sectorbuilder.TempSectorbuilderDir(paths, sectorSize, ds)
+	sb, err = sectorbuilder.TempSectorbuilderDir(paths, sealProofType, postProofType, ds)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -256,7 +256,7 @@ func TestSealPoStNoCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sb, err := sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sectorSize, ds)
+	sb, err := sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sealProofType, postProofType, ds)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -285,7 +285,7 @@ func TestSealPoStNoCommit(t *testing.T) {
 	precommit := time.Now()
 
 	// Restart sectorbuilder, re-run post
-	sb, err = sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sectorSize, ds)
+	sb, err = sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sealProofType, postProofType, ds)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -318,7 +318,7 @@ func TestSealAndVerify2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sb, err := sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sectorSize, ds)
+	sb, err := sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sealProofType, postProofType, ds)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -366,7 +366,7 @@ func TestAcquireID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sb, err := sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sectorSize, ds)
+	sb, err := sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sealProofType, postProofType, ds)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -381,7 +381,7 @@ func TestAcquireID(t *testing.T) {
 	assertAcquire(2)
 	assertAcquire(3)
 
-	sb, err = sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sectorSize, ds)
+	sb, err = sectorbuilder.TempSectorbuilderDir(sectorbuilder.SimplePath(dir), sealProofType, postProofType, ds)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/sectorbuilder_test.go
+++ b/sectorbuilder_test.go
@@ -91,8 +91,9 @@ func post(t *testing.T, sb *sectorbuilder.SectorBuilder, seals ...seal) time.Tim
 	psis := make([]ffi.PublicSectorInfo, len(seals))
 	for i, s := range seals {
 		psis[i] = ffi.PublicSectorInfo{
-			SectorNum: s.num,
-			SealedCID: s.sealedCID,
+			PoStProofType: postProofType,
+			SealedCID:     s.sealedCID,
+			SectorNum:     s.num,
 		}
 	}
 

--- a/simple.go
+++ b/simple.go
@@ -6,11 +6,10 @@ import (
 	"context"
 	"io"
 
-	"github.com/ipfs/go-cid"
-
 	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
+	"github.com/ipfs/go-cid"
 	"go.opencensus.io/trace"
 )
 

--- a/types.go
+++ b/types.go
@@ -63,8 +63,8 @@ type remote struct {
 }
 
 type JsonRSPCO struct {
-	CommD []byte
-	CommR []byte
+	CommD []byte // UnsealedCID
+	CommR []byte // SealedCID
 }
 
 type SealRes struct {

--- a/types.go
+++ b/types.go
@@ -62,7 +62,7 @@ type remote struct {
 	busy      uint64 // only for metrics
 }
 
-type JsonRSPCO struct {
+type JsonEncodablePreCommitOutput struct {
 	CommD []byte // UnsealedCID
 	CommR []byte // SealedCID
 }
@@ -72,5 +72,5 @@ type SealRes struct {
 	GoErr error `json:"-"`
 
 	Proof abi.SealProof
-	Rspco JsonRSPCO
+	Rspco JsonEncodablePreCommitOutput
 }

--- a/types.go
+++ b/types.go
@@ -21,10 +21,11 @@ type SectorBuilder struct {
 	ds    datastore.Batching
 	numLk sync.Mutex
 
-	ssize         abi.SectorSize
-	lastNum       abi.SectorNumber
+	lastNum abi.SectorNumber
+
 	sealProofType abi.RegisteredProof
 	postProofType abi.RegisteredProof
+	ssize         abi.SectorSize // a function of sealProofType and postProofType
 
 	Miner address.Address
 

--- a/types.go
+++ b/types.go
@@ -3,28 +3,12 @@ package sectorbuilder
 import (
 	"sync"
 
-	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-datastore"
 
 	"github.com/filecoin-project/go-sectorbuilder/fs"
 )
-
-type SortedPublicSectorInfo = ffi.SortedPublicSectorInfo
-type SortedPrivateSectorInfo = ffi.SortedPrivateSectorInfo
-
-type SealTicket = ffi.SealTicket
-
-type SealSeed = ffi.SealSeed
-
-type PublicPieceInfo = ffi.PublicPieceInfo
-
-type RawSealPreCommitOutput ffi.RawSealPreCommitOutput
-
-type EPostCandidate = ffi.Candidate
-
-const CommLen = ffi.CommitmentBytesLen
 
 type WorkerCfg struct {
 	NoPreCommit bool
@@ -37,8 +21,10 @@ type SectorBuilder struct {
 	ds    datastore.Batching
 	numLk sync.Mutex
 
-	ssize   abi.SectorSize
-	lastNum abi.SectorNumber
+	ssize         abi.SectorSize
+	lastNum       abi.SectorNumber
+	sealProofType abi.RegisteredProof
+	postProofType abi.RegisteredProof
 
 	Miner address.Address
 
@@ -84,6 +70,6 @@ type SealRes struct {
 	Err   string
 	GoErr error `json:"-"`
 
-	Proof []byte
+	Proof abi.SealProof
 	Rspco JsonRSPCO
 }


### PR DESCRIPTION
## Why does this PR exist?

The proofs team has release their versioned API, and we want to use it. The proofs team gave us Poseidon, and we want that too. The specs team gave us specs-actors types, and those are great. Why not do it all in one shot?

## What's in this PR?

- updates to use the fancy specs-actors types
- consume new two-phase pre-commit and commit API
- consume new versioned proofs API