### PR TITLE
Update/v23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,10 @@ jobs:
   build-all:
     executor: golang
     steps:
+      - run:
+          name: Install Rust
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
       - install-deps
       - prepare
       - go/mod-download

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/filecoin-project/go-sectorbuilder
 go 1.13
 
 require (
-	github.com/filecoin-project/filecoin-ffi v0.0.0-20191219131535-bb699517a590
-	github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5
+	github.com/filecoin-project/filecoin-ffi v0.0.0-20200226202622-0a68e6603990
+	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
-	github.com/filecoin-project/specs-actors v0.0.0-20200225235005-cd871b9e0267
+	github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/ipfs/go-cid v0.0.5
 	github.com/ipfs/go-datastore v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
-	github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341
+	github.com/filecoin-project/specs-actors v0.0.0-20200225235005-cd871b9e0267
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect
 	github.com/ipfs/go-cid v0.0.5
 	github.com/ipfs/go-datastore v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/filecoin-project/go-sectorbuilder
 go 1.13
 
 require (
-	github.com/filecoin-project/filecoin-ffi v0.0.0-20200226202622-0a68e6603990
+	github.com/filecoin-project/filecoin-ffi v0.0.0-20200226205820-4da0bccccefb
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/fatih/color v1.8.0 h1:5bzFgL+oy7JITMTxUPJ00n7VxmYd/PdMp5mHFX40/RY=
 github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGjnw8=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
 github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
+github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:TooKBwR/g8jG0hZ3lqe9S5sy2vTUcLOZLlz3M5wGn2E=
+github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
@@ -31,6 +33,8 @@ github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341 h1:m
 github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200225235005-cd871b9e0267 h1:AJUljSeIuWQRzpBJdFsgNMM1hKwyNX64OMUzorqbV/4=
 github.com/filecoin-project/specs-actors v0.0.0-20200225235005-cd871b9e0267/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
+github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775 h1:j6EdTc5hIHe31ydt9SjgJNDi/ck50y5wa1OJ+4YZ6zk=
+github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775/go.mod h1:0HAWYrvajFHDgRaKbF0rl+IybVLZL5z4gQ8koCMPhoU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 h
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
 github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341 h1:mDfwS/9ck3lQH9+xZfDTj6kpp12g77q0dHT2+94QYEI=
 github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
+github.com/filecoin-project/specs-actors v0.0.0-20200225235005-cd871b9e0267 h1:AJUljSeIuWQRzpBJdFsgNMM1hKwyNX64OMUzorqbV/4=
+github.com/filecoin-project/specs-actors v0.0.0-20200225235005-cd871b9e0267/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.8.0 h1:5bzFgL+oy7JITMTxUPJ00n7VxmYd/PdMp5mHFX40/RY=
 github.com/fatih/color v1.8.0/go.mod h1:3l45GVGkyrnYNl9HoIjnp2NnNWvh6hLAqD8yTfGjnw8=
-github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5 h1:/MmWluswvDIbuPvBct4q6HeQgVm62O2DzWYTB38kt4A=
-github.com/filecoin-project/go-address v0.0.0-20200107215422-da8eea2842b5/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:TooKBwR/g8jG0hZ3lqe9S5sy2vTUcLOZLlz3M5wGn2E=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
@@ -29,10 +27,6 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663 h1:eYxi6vI5CyeXD15X1bB3bledDXbqKxqf0wQzTLgwYwA=
 github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663/go.mod h1:fZzmf4tftbwf9S37XRifoJlz7nCjRdIrMGLR07dKLCc=
-github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341 h1:mDfwS/9ck3lQH9+xZfDTj6kpp12g77q0dHT2+94QYEI=
-github.com/filecoin-project/specs-actors v0.0.0-20200213011857-91a589664341/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
-github.com/filecoin-project/specs-actors v0.0.0-20200225235005-cd871b9e0267 h1:AJUljSeIuWQRzpBJdFsgNMM1hKwyNX64OMUzorqbV/4=
-github.com/filecoin-project/specs-actors v0.0.0-20200225235005-cd871b9e0267/go.mod h1:xtDZUB6pe4Pksa/bAJbJ693OilaC5Wbot9jMhLm3cZA=
 github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775 h1:j6EdTc5hIHe31ydt9SjgJNDi/ck50y5wa1OJ+4YZ6zk=
 github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775/go.mod h1:0HAWYrvajFHDgRaKbF0rl+IybVLZL5z4gQ8koCMPhoU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/interface.go
+++ b/interface.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"io"
 
-	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
+
+	ffi "github.com/filecoin-project/filecoin-ffi"
 
 	"github.com/filecoin-project/go-sectorbuilder/fs"
 )
@@ -21,8 +21,8 @@ type Interface interface {
 	Scrub([]abi.SectorNumber) []*Fault
 
 	GenerateEPostCandidates(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, error)
-	GenerateFallbackPoSt(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, []byte, error)
-	ComputeElectionPoSt(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, winners []abi.PoStCandidate) ([]byte, error)
+	GenerateFallbackPoSt(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, []abi.PoStProof, error)
+	ComputeElectionPoSt(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, winners []abi.PoStCandidate) ([]abi.PoStProof, error)
 
 	SealPreCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, pieces []abi.PieceInfo) (sealedCID cid.Cid, unsealedCID cid.Cid, err error)
 	SealCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof abi.SealProof, err error)
@@ -44,7 +44,7 @@ type Interface interface {
 type UnpaddedByteIndex uint64
 
 type Verifier interface {
-	VerifySeal(proofType abi.RegisteredProof, sealedCID, unsealedCID cid.Cid, prover address.Address, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, sectorNum abi.SectorNumber, proof abi.SealProof) (bool, error)
-	VerifyElectionPost(ctx context.Context, sectorInfo ffi.SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []abi.PoStCandidate, prover address.Address) (bool, error)
-	VerifyFallbackPost(ctx context.Context, sectorInfo ffi.SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []abi.PoStCandidate, prover address.Address, faults uint64) (bool, error)
+	VerifySeal(abi.SealVerifyInfo) (bool, error)
+	VerifyElectionPost(ctx context.Context, info abi.PoStVerifyInfo) (bool, error)
+	VerifyFallbackPost(ctx context.Context, info abi.PoStVerifyInfo) (bool, error)
 }

--- a/interface.go
+++ b/interface.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"io"
 
+	ffi "github.com/filecoin-project/filecoin-ffi"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
-
-	ffi "github.com/filecoin-project/filecoin-ffi"
 
 	"github.com/filecoin-project/go-sectorbuilder/fs"
 )
@@ -20,9 +19,9 @@ type Interface interface {
 	AcquireSectorNumber() (abi.SectorNumber, error)
 	Scrub([]abi.SectorNumber) []*Fault
 
-	GenerateEPostCandidates(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, error)
-	GenerateFallbackPoSt(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, []abi.PoStProof, error)
-	ComputeElectionPoSt(sectorInfo ffi.SortedPublicSectorInfo, challengeSeed abi.PoStRandomness, winners []abi.PoStCandidate) ([]abi.PoStProof, error)
+	GenerateEPostCandidates(sectorInfo []abi.SectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, error)
+	GenerateFallbackPoSt(sectorInfo []abi.SectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, []abi.PoStProof, error)
+	ComputeElectionPoSt(sectorInfo []abi.SectorInfo, challengeSeed abi.PoStRandomness, winners []abi.PoStCandidate) ([]abi.PoStProof, error)
 
 	SealPreCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, pieces []abi.PieceInfo) (sealedCID cid.Cid, unsealedCID cid.Cid, err error)
 	SealCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof abi.SealProof, err error)

--- a/interface.go
+++ b/interface.go
@@ -24,7 +24,7 @@ type Interface interface {
 	ComputeElectionPoSt(sectorInfo []abi.SectorInfo, challengeSeed abi.PoStRandomness, winners []abi.PoStCandidate) ([]abi.PoStProof, error)
 
 	SealPreCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, pieces []abi.PieceInfo) (sealedCID cid.Cid, unsealedCID cid.Cid, err error)
-	SealCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof abi.SealProof, err error)
+	SealCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof []byte, err error)
 	// FinalizeSector cleans up cache, and moves it to storage filesystem
 	FinalizeSector(context.Context, abi.SectorNumber) error
 	DropStaged(context.Context, abi.SectorNumber) error

--- a/parameters.json
+++ b/parameters.json
@@ -1,102 +1,82 @@
 {
-  "v22-proof-of-spacetime-election-PoseidonHasher-0b0b9781bcb153efbb3cab4be3a792c4f555d4ab6f8dd62b27e1dcad08a34f22.params": {
-    "cid": "QmQ6dHcrtuXGpmsbZH72W223b3hdSKGtR9oaSMwsM9NkzD",
-    "digest": "a0799a458f44626bac7df3093b0294e4",
+  "v23-proof-of-spacetime-election-PoseidonHasher-0b0b9781bcb153efbb3cab4be3a792c4f555d4ab6f8dd62b27e1dcad08a34f22.params": {
+    "cid": "Qmcqu1sgXs8p1mn8n9bCYovGgarCK5LvqFWbrCnYDxxjnq",
+    "digest": "558ff029bef32ed76d87f5e448a03bd3",
     "sector_size": 34359738368
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-0b0b9781bcb153efbb3cab4be3a792c4f555d4ab6f8dd62b27e1dcad08a34f22.vk": {
-    "cid": "QmS5Vxn9uzZfyGoZJHSj3ZDdEeRd8nEczqJR5CsQd7pSJG",
-    "digest": "ce4a1b197b23d0aa10315dbf9bc522a0",
+  "v23-proof-of-spacetime-election-PoseidonHasher-0b0b9781bcb153efbb3cab4be3a792c4f555d4ab6f8dd62b27e1dcad08a34f22.vk": {
+    "cid": "QmS1SdHpnipjjcbnEG6b9T2q4rF6h8hc1jtZgEn5XBXW4o",
+    "digest": "2eca950d71d47b54125446f58d997035",
     "sector_size": 34359738368
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-0ffac504e6feaec47f7baf3eb1b451690c0aa7e726b749cf030819f947d81bf7.params": {
-    "cid": "QmS8M8iXyAHApXBLdJ6st9PJhw36wHZtQ3dn2q47ZXuvWN",
-    "digest": "385b6a6e2748e56598685413bf3aaede",
-    "sector_size": 1024
+  "v23-proof-of-spacetime-election-PoseidonHasher-0b499a953f1a9dcab420b3ba1e6b1f3952dc7f17cf67ed10406ae9a43e2b8ec5.params": {
+    "cid": "QmbuwgxzqLKKutGBR4ay7jfPWATNynYUMGrwj8jCMG2pwN",
+    "digest": "7f9c06a57c8f2c029de378d63ba0b4c8",
+    "sector_size": 8388608
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-0ffac504e6feaec47f7baf3eb1b451690c0aa7e726b749cf030819f947d81bf7.vk": {
-    "cid": "QmYSidQXSbuftzNnMiXsGV1hLAtsB94EPBHzH1LvXdWgn7",
-    "digest": "938abd0f3416c6ae1e8dd21fa4d92b4e",
-    "sector_size": 1024
+  "v23-proof-of-spacetime-election-PoseidonHasher-0b499a953f1a9dcab420b3ba1e6b1f3952dc7f17cf67ed10406ae9a43e2b8ec5.vk": {
+    "cid": "QmXt3hXJR4XjdE3uLyhTYvRuCLhCkmfGnK9sbYXmGZ4mgs",
+    "digest": "2565ed8c01783d1fc8c6b1814a84dfbb",
+    "sector_size": 8388608
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-9b5673a5c0df861151c2b8087fe4f0d8657558d07ce768b7067dab2eea76dad4.params": {
-    "cid": "QmX957ftCjZehyNSVUFLi6kqF7nsSh2gf2kNVgTekCA5K4",
-    "digest": "9b47a0e0da9350be2c5627d5b5c55ba1",
-    "sector_size": 16777216
+  "v23-proof-of-spacetime-election-PoseidonHasher-27a7fc680a47e4821f40cf1676fb80b9888820ef6867a71a175b4c9ae068ad3f.params": {
+    "cid": "QmXn1SNAERUJWXkkdEUcYLTpsde6KStUPWpG5jCZNjDphy",
+    "digest": "21b612f054cead6cb7416932c98ad93d",
+    "sector_size": 536870912
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-9b5673a5c0df861151c2b8087fe4f0d8657558d07ce768b7067dab2eea76dad4.vk": {
-    "cid": "QmSTTzD5jvqRzBGj67mzjj75WfAoG9ntkwq28u2ckh9odA",
-    "digest": "dee344a21099eb6487df78598ba59640",
-    "sector_size": 16777216
+  "v23-proof-of-spacetime-election-PoseidonHasher-27a7fc680a47e4821f40cf1676fb80b9888820ef6867a71a175b4c9ae068ad3f.vk": {
+    "cid": "QmS2b2157k1MgyAtdC8cP4wAxau4PbJPCLzaqx9hxgpbe7",
+    "digest": "4a198ab9cf20245e1783d346d0ba7fe5",
+    "sector_size": 536870912
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-cd7aba426e27fc8e65abd777be0908fb536aa550c09a00ebae7596206f83b107.params": {
-    "cid": "QmWaQ6bupbWM76ALbb61SkFmsKRGV9Rek9Y2ieGsJEyCgT",
-    "digest": "f91e462f2d21bd9ae4b21196b784f081",
-    "sector_size": 1073741824
+  "v23-proof-of-spacetime-election-PoseidonHasher-5916054ae98e28fc2f0470d1fb58eb875a6865be86f0b8c4e302d55f13217fef.params": {
+    "cid": "QmPY3BG7gZmQKnprsepGfgHdS5MwjV9Cqqi4YrYJZyvRuv",
+    "digest": "386a70fe0e4ce16942b99e0694a3ce84",
+    "sector_size": 2048
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-cd7aba426e27fc8e65abd777be0908fb536aa550c09a00ebae7596206f83b107.vk": {
-    "cid": "QmYxJeX37TLBjYz9kEKNBtwrM3SqRXGavHMWTCB8P2bhoH",
-    "digest": "c6467c4f0d70e0fbb23d705d1f5f0245",
-    "sector_size": 1073741824
+  "v23-proof-of-spacetime-election-PoseidonHasher-5916054ae98e28fc2f0470d1fb58eb875a6865be86f0b8c4e302d55f13217fef.vk": {
+    "cid": "QmTikzLJfqC1izpbZP2BEw5GWAEJrUiKzWj4EyCPBtqgVT",
+    "digest": "c1750423edbd09ec94fcbc8538209f1a",
+    "sector_size": 2048
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-fe3e586b9bc36865d0fb0da9fd8d336b5ef10a0c1abf2a887ffca440b0cfe069.params": {
-    "cid": "QmbhQPh8Sahx3iW6pvZPj3EDSVjGMXmxwMv5TD8H4BFg3E",
-    "digest": "d6ffbfaf96b34ed8549db6d81c5e3efa",
-    "sector_size": 268435456
+  "v23-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-49442c8ce7545579cbd689d578301d0cc1e46e94e2499a0ec36de7ff4f4694a2.params": {
+    "cid": "QmdkRUVf7iBA5qYv5WFKdBN5fzsmGrKLRJs3F8PtR3azAc",
+    "digest": "d8a4f1ff91b7b0395bae850d1277fc74",
+    "sector_size": 8388608
   },
-  "v22-proof-of-spacetime-election-PoseidonHasher-fe3e586b9bc36865d0fb0da9fd8d336b5ef10a0c1abf2a887ffca440b0cfe069.vk": {
-    "cid": "Qmc7yEwQG6qigYNMWrJBRfMwgaMoUW3XVdanPdnKCaeLiQ",
-    "digest": "2965f17ecc9ec6c9f5a27a4f4940b55c",
-    "sector_size": 268435456
+  "v23-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-49442c8ce7545579cbd689d578301d0cc1e46e94e2499a0ec36de7ff4f4694a2.vk": {
+    "cid": "Qmdmrp75NToB9b6vxh5gZcECEHiGxxP8NRLhcVt7B9SjqQ",
+    "digest": "ad2d7a1931ffb996278245cda162a2ea",
+    "sector_size": 8388608
   },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-2824c92b9812d2ef306376a6c96b6edab9247472bccf6485a64b7d6f7e1031cb.params": {
-    "cid": "QmUu5NCkCSwKXpHygPwamy2ZVgaqwUSe4UZUVGcoxxK1rX",
-    "digest": "03f9fbf59d4b028eefe62991244d314c",
-    "sector_size": 268435456
+  "v23-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-d84aa4581c74190f845596893ebe5b71da32ecf16e1d151b9fff74ee8f94d77c.params": {
+    "cid": "QmcAn3A6iBPAcvHZWv4CG2KDg73T9kE5VvLYe9XrEmVQQd",
+    "digest": "dccdeb3bed61a7ca0184241c290970c9",
+    "sector_size": 536870912
   },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-2824c92b9812d2ef306376a6c96b6edab9247472bccf6485a64b7d6f7e1031cb.vk": {
-    "cid": "QmSZPeySPfL9HAiakDda9ZRFce8WqVMRANPo6jqrT7Byf7",
-    "digest": "48d7eb2efaf6786a893e40f655907814",
-    "sector_size": 268435456
+  "v23-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-d84aa4581c74190f845596893ebe5b71da32ecf16e1d151b9fff74ee8f94d77c.vk": {
+    "cid": "QmWwLsV5wrkoWhrTmQCE62J5o3tmdvFDTznEy4N1Wsknqg",
+    "digest": "ce3d9951ebde0b10419339f26d604ba7",
+    "sector_size": 536870912
   },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-97898c09be471d01d125f93ba4dd8d1a5634e404c1c7d1ea21014d0c8656a29a.params": {
-    "cid": "QmcGxjoa7WU9cphRzRyHJ2aM1EsQdo7ZVPiCPVjbRShpH2",
-    "digest": "f9915452f4547bbb93663cec214626cd",
-    "sector_size": 1073741824
-  },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-97898c09be471d01d125f93ba4dd8d1a5634e404c1c7d1ea21014d0c8656a29a.vk": {
-    "cid": "Qmc9tXAG99A8ykiV5AwXenKTfd2GXtLA6RdWYyhyT9J6c8",
-    "digest": "48c207aa03b9db61ed595b02ff380d80",
-    "sector_size": 1073741824
-  },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-b9678fc0c28dfcec342ca4c7886020d583b16258c9bc93aafad679d09400e401.params": {
-    "cid": "QmUxFUyjutaf4yZwtjij7Gd5oxDqfHpLNVjBXaNLnbHPeB",
-    "digest": "3a648b28e0b2795f58868ef964af8e09",
-    "sector_size": 1024
-  },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-b9678fc0c28dfcec342ca4c7886020d583b16258c9bc93aafad679d09400e401.vk": {
-    "cid": "Qmai7WbNjxW7MC8uQzXKeRBFdGLBSFMXx6m8c1dTiqtsrK",
-    "digest": "200daeec486802fc1310fbb5baad42d5",
-    "sector_size": 1024
-  },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-f4bdecc971c681000d2e56d2e8f40877710978727ff383550bdc6202cdcdd9cd.params": {
-    "cid": "QmWcJUuJHyDZZWfmhq9nLVYAZxxCFozjD8axPYwUpk9HhL",
-    "digest": "337735473a92e4b4d9335180c5463340",
-    "sector_size": 16777216
-  },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-f4bdecc971c681000d2e56d2e8f40877710978727ff383550bdc6202cdcdd9cd.vk": {
-    "cid": "QmUAcZ32NWndqMEuYs5HhULqw9XgbJnEsrSANXjs4YBJys",
-    "digest": "1bd4cddb08b94a1af8c63e7559e27a75",
-    "sector_size": 16777216
-  },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-fc32be6028c2398175466f36fa36810842ae8948fae15c84454af5b61ca99e15.params": {
-    "cid": "QmNVR2z1aT6FQLFtx35AhJ8zyR8hyJyxTbxMx2NvUkDrky",
-    "digest": "41b102d948130449afbce487b16d148f",
+  "v23-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-fc32be6028c2398175466f36fa36810842ae8948fae15c84454af5b61ca99e15.params": {
+    "cid": "Qmama5rJYTHFQbjamAuv3nyrJ8TYwg38hyKTs5rHM4F1s5",
+    "digest": "d600e36f91e0ec5d1e44aa9de0cc2901",
     "sector_size": 34359738368
   },
-  "v22-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-fc32be6028c2398175466f36fa36810842ae8948fae15c84454af5b61ca99e15.vk": {
-    "cid": "QmbPxsRdS7yr6aEHXWDoRvMnvtz9LqTj7DAH4i7AyTetpq",
-    "digest": "70e806d302ee8828faa3b07d2dace2a8",
+  "v23-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-fc32be6028c2398175466f36fa36810842ae8948fae15c84454af5b61ca99e15.vk": {
+    "cid": "QmXnCBjLn8mJhQibrmdzwD8LKWVJf8MZvqTNSYYBZnfC7M",
+    "digest": "5fdf47c8b367f9dfa4d763eb70bef759",
     "sector_size": 34359738368
+  },
+  "v23-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-fe437922fe766f61b112750506d6be0e4ad5daa85ff9ce96549d99253ba61cbe.params": {
+    "cid": "QmPUL7h51m671KGZaKB6nruAXtzFbMVwHousSnrPP4QtCH",
+    "digest": "fcd772f59cdb2d1124fe0edc8b402bda",
+    "sector_size": 2048
+  },
+  "v23-stacked-proof-of-replication-PoseidonHasher-Sha256Hasher-fe437922fe766f61b112750506d6be0e4ad5daa85ff9ce96549d99253ba61cbe.vk": {
+    "cid": "QmaBZ83AuRzWkAT3QNtt5H7kQMnf5YT66ah6Q7DDMy6N9K",
+    "digest": "4ce2e879f537d085d872cae46f0b3365",
+    "sector_size": 2048
   }
 }

--- a/sectorbuild_cgo.go
+++ b/sectorbuild_cgo.go
@@ -286,7 +286,7 @@ func (sb *SectorBuilder) SealPreCommit(ctx context.Context, sectorNum abi.Sector
 	return sealedCID, unsealedCID, nil
 }
 
-func (sb *SectorBuilder) sealCommitLocal(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof abi.SealProof, err error) {
+func (sb *SectorBuilder) sealCommitLocal(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof []byte, err error) {
 	atomic.AddInt32(&sb.commitWait, -1)
 
 	defer func() {
@@ -295,25 +295,25 @@ func (sb *SectorBuilder) sealCommitLocal(ctx context.Context, sectorNum abi.Sect
 
 	cacheDir, err := sb.SectorPath(fs.DataCache, sectorNum)
 	if err != nil {
-		return abi.SealProof{}, err
+		return []byte{}, err
 	}
 	if err := sb.filesystem.Lock(ctx, cacheDir); err != nil {
-		return abi.SealProof{}, err
+		return []byte{}, err
 	}
 	defer sb.filesystem.Unlock(cacheDir)
 
 	sealedPath, err := sb.SectorPath(fs.DataSealed, sectorNum)
 	if err != nil {
-		return abi.SealProof{}, xerrors.Errorf("get sealed: %w", err)
+		return []byte{}, xerrors.Errorf("get sealed: %w", err)
 	}
 	if err := sb.filesystem.Lock(ctx, sealedPath); err != nil {
-		return abi.SealProof{}, err
+		return []byte{}, err
 	}
 	defer sb.filesystem.Unlock(sealedPath)
 
 	mid, err := address.IDFromAddress(sb.Miner)
 	if err != nil {
-		return abi.SealProof{}, err
+		return []byte{}, err
 	}
 
 	output, err := ffi.SealCommitPhase1(
@@ -332,13 +332,13 @@ func (sb *SectorBuilder) sealCommitLocal(ctx context.Context, sectorNum abi.Sect
 		log.Warn("StandaloneSealCommit error: ", err)
 		log.Warnf("num:%d tkt:%v seed:%v, pi:%v sealedCID:%v, unsealedCID:%v", sectorNum, ticket, seed, pieces, sealedCID, unsealedCID)
 
-		return abi.SealProof{}, xerrors.Errorf("StandaloneSealCommit: %w", err)
+		return []byte{}, xerrors.Errorf("StandaloneSealCommit: %w", err)
 	}
 
 	return ffi.SealCommitPhase2(output, sectorNum, abi.ActorID(mid))
 }
 
-func (sb *SectorBuilder) SealCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof abi.SealProof, err error) {
+func (sb *SectorBuilder) SealCommit(ctx context.Context, sectorNum abi.SectorNumber, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, pieces []abi.PieceInfo, sealedCID cid.Cid, unsealedCID cid.Cid) (proof []byte, err error) {
 	call := workerCall{
 		task: WorkerTask{
 			Pieces:      pieces,
@@ -372,11 +372,11 @@ func (sb *SectorBuilder) SealCommit(ctx context.Context, sectorNum abi.SectorNum
 		case rl <- struct{}{}:
 			proof, err = sb.sealCommitLocal(ctx, sectorNum, ticket, seed, pieces, sealedCID, unsealedCID)
 		case <-ctx.Done():
-			return abi.SealProof{}, ctx.Err()
+			return []byte{}, ctx.Err()
 		}
 	}
 	if err != nil {
-		return abi.SealProof{}, xerrors.Errorf("commit: %w", err)
+		return []byte{}, xerrors.Errorf("commit: %w", err)
 	}
 
 	return proof, nil

--- a/sectorbuild_cgo.go
+++ b/sectorbuild_cgo.go
@@ -388,7 +388,7 @@ func (sb *SectorBuilder) ComputeElectionPoSt(sectorInfo []abi.SectorInfo, challe
 		return nil, err
 	}
 
-	privsects, err := sb.pubSectorToPriv(sb.postProofType, sectorInfo, nil) // TODO: faults
+	privsects, err := sb.pubSectorToPriv(sectorInfo, nil) // TODO: faults
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func (sb *SectorBuilder) GenerateEPostCandidates(sectorInfo []abi.SectorInfo, ch
 		return nil, err
 	}
 
-	privsectors, err := sb.pubSectorToPriv(sb.postProofType, sectorInfo, faults)
+	privsectors, err := sb.pubSectorToPriv(sectorInfo, faults)
 	if err != nil {
 		return nil, err
 	}
@@ -413,7 +413,7 @@ func (sb *SectorBuilder) GenerateEPostCandidates(sectorInfo []abi.SectorInfo, ch
 }
 
 func (sb *SectorBuilder) GenerateFallbackPoSt(sectorInfo []abi.SectorInfo, challengeSeed abi.PoStRandomness, faults []abi.SectorNumber) ([]ffi.PoStCandidateWithTicket, []abi.PoStProof, error) {
-	privsectors, err := sb.pubSectorToPriv(sb.postProofType, sectorInfo, faults)
+	privsectors, err := sb.pubSectorToPriv(sectorInfo, faults)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -286,9 +286,11 @@ func (sb *SectorBuilder) pubSectorToPriv(sectorInfo ffi.SortedPublicSectorInfo, 
 		out = append(out, ffi.PrivateSectorInfo{
 			CacheDirPath:     string(cachePath),
 			PoStProofType:    s.PoStProofType,
-			SealedCID:        s.SealedCID,
 			SealedSectorPath: string(sealedPath),
-			SectorNum:        s.SectorNum,
+			SectorInfo: abi.SectorInfo{
+				SectorNumber: s.SectorNum,
+				SealedCID:    s.SealedCID,
+			},
 		})
 	}
 
@@ -445,30 +447,22 @@ func sizeFromConfig(cfg Config) (abi.SectorSize, error) {
 
 func sizeFromProofType(p abi.RegisteredProof) (abi.SectorSize, error) {
 	switch p {
-	case abi.RegisteredProof_WinStackedDRG32GiBSeal:
-		return 1 << 35, nil
-	case abi.RegisteredProof_WinStackedDRG32GiBPoSt:
-		return 1 << 35, nil
 	case abi.RegisteredProof_StackedDRG32GiBSeal:
-		return 1 << 35, nil
+		return 32 << 30, nil
 	case abi.RegisteredProof_StackedDRG32GiBPoSt:
-		return 1 << 35, nil
-	case abi.RegisteredProof_StackedDRG1KiBSeal:
-		return 1024, nil
-	case abi.RegisteredProof_StackedDRG1KiBPoSt:
-		return 1024, nil
-	case abi.RegisteredProof_StackedDRG16MiBSeal:
-		return 1 << 24, nil
-	case abi.RegisteredProof_StackedDRG16MiBPoSt:
-		return 1 << 24, nil
-	case abi.RegisteredProof_StackedDRG256MiBSeal:
-		return 1 << 28, nil
-	case abi.RegisteredProof_StackedDRG256MiBPoSt:
-		return 1 << 28, nil
-	case abi.RegisteredProof_StackedDRG1GiBSeal:
-		return 1 << 30, nil
-	case abi.RegisteredProof_StackedDRG1GiBPoSt:
-		return 1 << 30, nil
+		return 32 << 20, nil
+	case abi.RegisteredProof_StackedDRG2KiBSeal:
+		return 2 << 10, nil
+	case abi.RegisteredProof_StackedDRG2KiBPoSt:
+		return 2 << 10, nil
+	case abi.RegisteredProof_StackedDRG8MiBSeal:
+		return 8 << 20, nil
+	case abi.RegisteredProof_StackedDRG8MiBPoSt:
+		return 8 << 20, nil
+	case abi.RegisteredProof_StackedDRG512MiBSeal:
+		return 512 << 20, nil
+	case abi.RegisteredProof_StackedDRG512MiBPoSt:
+		return 512 << 20, nil
 	default:
 		return abi.SectorSize(0), errors.Errorf("unsupported proof type: %+v", p)
 	}

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -247,7 +247,7 @@ func (sb *SectorBuilder) sealPreCommitRemote(call workerCall) (sealedCID cid.Cid
 	}
 }
 
-func (sb *SectorBuilder) sealCommitRemote(call workerCall) (proof abi.SealProof, err error) {
+func (sb *SectorBuilder) sealCommitRemote(call workerCall) (proof []byte, err error) {
 	atomic.AddInt32(&sb.commitWait, -1)
 
 	select {
@@ -257,7 +257,7 @@ func (sb *SectorBuilder) sealCommitRemote(call workerCall) (proof abi.SealProof,
 		}
 		return ret.Proof, err
 	case <-sb.stopping:
-		return abi.SealProof{}, xerrors.New("sectorbuilder stopped")
+		return []byte{}, xerrors.New("sectorbuilder stopped")
 	}
 }
 
@@ -287,10 +287,7 @@ func (sb *SectorBuilder) pubSectorToPriv(postProofType abi.RegisteredProof, sect
 			CacheDirPath:     string(cachePath),
 			PoStProofType:    postProofType,
 			SealedSectorPath: string(sealedPath),
-			SectorInfo: abi.SectorInfo{
-				SectorNumber: s.SectorNumber,
-				SealedCID:    s.SealedCID,
-			},
+			SectorInfo:       s,
 		})
 	}
 

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -445,7 +445,7 @@ func sizeFromConfig(cfg Config) (abi.SectorSize, error) {
 func sizeFromProofType(p abi.RegisteredProof) (abi.SectorSize, error) {
 	switch p {
 	case abi.RegisteredProof_StackedDRG32GiBSeal:
-		return 32 << 30, nil
+		return 32 << 20, nil
 	case abi.RegisteredProof_StackedDRG32GiBPoSt:
 		return 32 << 20, nil
 	case abi.RegisteredProof_StackedDRG2KiBSeal:

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -261,7 +261,7 @@ func (sb *SectorBuilder) sealCommitRemote(call workerCall) (proof []byte, err er
 	}
 }
 
-func (sb *SectorBuilder) pubSectorToPriv(postProofType abi.RegisteredProof, sectorInfo []abi.SectorInfo, faults []abi.SectorNumber) (ffi.SortedPrivateSectorInfo, error) {
+func (sb *SectorBuilder) pubSectorToPriv(sectorInfo []abi.SectorInfo, faults []abi.SectorNumber) (ffi.SortedPrivateSectorInfo, error) {
 	fmap := map[abi.SectorNumber]struct{}{}
 	for _, fault := range faults {
 		fmap[fault] = struct{}{}
@@ -281,6 +281,11 @@ func (sb *SectorBuilder) pubSectorToPriv(postProofType abi.RegisteredProof, sect
 		sealedPath, err := sb.SectorPath(fs.DataSealed, s.SectorNumber)
 		if err != nil {
 			return ffi.SortedPrivateSectorInfo{}, xerrors.Errorf("getting sealed paths for sector %d: %w", s.SectorNumber, err)
+		}
+
+		postProofType, err := s.RegisteredProof.RegisteredPoStProof()
+		if err != nil {
+			return ffi.SortedPrivateSectorInfo{}, xerrors.Errorf("acquiring registered PoSt proof from sector info %+v: %w", s, err)
 		}
 
 		out = append(out, ffi.PrivateSectorInfo{

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -448,23 +448,20 @@ func sizeFromConfig(cfg Config) (abi.SectorSize, error) {
 }
 
 func sizeFromProofType(p abi.RegisteredProof) (abi.SectorSize, error) {
-	switch p {
-	case abi.RegisteredProof_StackedDRG32GiBSeal:
-		return 32 << 20, nil
+	x, err := p.RegisteredPoStProof()
+	if err != nil {
+		return 0, err
+	}
+
+	switch x {
 	case abi.RegisteredProof_StackedDRG32GiBPoSt:
-		return 32 << 20, nil
-	case abi.RegisteredProof_StackedDRG2KiBSeal:
-		return 2 << 10, nil
+		return 1 << 35, nil
 	case abi.RegisteredProof_StackedDRG2KiBPoSt:
-		return 2 << 10, nil
-	case abi.RegisteredProof_StackedDRG8MiBSeal:
-		return 8 << 20, nil
+		return 2048, nil
 	case abi.RegisteredProof_StackedDRG8MiBPoSt:
-		return 8 << 20, nil
-	case abi.RegisteredProof_StackedDRG512MiBSeal:
-		return 512 << 20, nil
+		return 1 << 23, nil
 	case abi.RegisteredProof_StackedDRG512MiBPoSt:
-		return 512 << 20, nil
+		return 1 << 29, nil
 	default:
 		return abi.SectorSize(0), errors.Errorf("unsupported proof type: %+v", p)
 	}

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -453,6 +453,8 @@ func sizeFromProofType(p abi.RegisteredProof) (abi.SectorSize, error) {
 		return 0, err
 	}
 
+	// values taken from https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/constants.rs#L11
+
 	switch x {
 	case abi.RegisteredProof_StackedDRG32GiBPoSt:
 		return 1 << 35, nil

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -257,7 +257,7 @@ func (sb *SectorBuilder) sealCommitRemote(call workerCall) (proof []byte, err er
 		}
 		return ret.Proof, err
 	case <-sb.stopping:
-		return []byte{}, xerrors.New("sectorbuilder stopped")
+		return nil, xerrors.New("sectorbuilder stopped")
 	}
 }
 

--- a/sectorbuilder.go
+++ b/sectorbuilder.go
@@ -261,34 +261,34 @@ func (sb *SectorBuilder) sealCommitRemote(call workerCall) (proof abi.SealProof,
 	}
 }
 
-func (sb *SectorBuilder) pubSectorToPriv(sectorInfo ffi.SortedPublicSectorInfo, faults []abi.SectorNumber) (ffi.SortedPrivateSectorInfo, error) {
+func (sb *SectorBuilder) pubSectorToPriv(postProofType abi.RegisteredProof, sectorInfo []abi.SectorInfo, faults []abi.SectorNumber) (ffi.SortedPrivateSectorInfo, error) {
 	fmap := map[abi.SectorNumber]struct{}{}
 	for _, fault := range faults {
 		fmap[fault] = struct{}{}
 	}
 
 	var out []ffi.PrivateSectorInfo
-	for _, s := range sectorInfo.Values() {
-		if _, faulty := fmap[s.SectorNum]; faulty {
+	for _, s := range sectorInfo {
+		if _, faulty := fmap[s.SectorNumber]; faulty {
 			continue
 		}
 
-		cachePath, err := sb.SectorPath(fs.DataCache, s.SectorNum) // TODO: LOCK!
+		cachePath, err := sb.SectorPath(fs.DataCache, s.SectorNumber) // TODO: LOCK!
 		if err != nil {
-			return ffi.SortedPrivateSectorInfo{}, xerrors.Errorf("getting cache paths for sector %d: %w", s.SectorNum, err)
+			return ffi.SortedPrivateSectorInfo{}, xerrors.Errorf("getting cache paths for sector %d: %w", s.SectorNumber, err)
 		}
 
-		sealedPath, err := sb.SectorPath(fs.DataSealed, s.SectorNum)
+		sealedPath, err := sb.SectorPath(fs.DataSealed, s.SectorNumber)
 		if err != nil {
-			return ffi.SortedPrivateSectorInfo{}, xerrors.Errorf("getting sealed paths for sector %d: %w", s.SectorNum, err)
+			return ffi.SortedPrivateSectorInfo{}, xerrors.Errorf("getting sealed paths for sector %d: %w", s.SectorNumber, err)
 		}
 
 		out = append(out, ffi.PrivateSectorInfo{
 			CacheDirPath:     string(cachePath),
-			PoStProofType:    s.PoStProofType,
+			PoStProofType:    postProofType,
 			SealedSectorPath: string(sealedPath),
 			SectorInfo: abi.SectorInfo{
-				SectorNumber: s.SectorNum,
+				SectorNumber: s.SectorNumber,
 				SealedCID:    s.SealedCID,
 			},
 		})

--- a/sectorbuilder_test.go
+++ b/sectorbuilder_test.go
@@ -32,7 +32,7 @@ func init() {
 	logging.SetLogLevel("*", "INFO") //nolint: errcheck
 }
 
-var sectorSize = abi.SectorSize(1024)
+var sectorSize = abi.SectorSize(2048)
 var sealProofType = abi.RegisteredProof_StackedDRG2KiBSeal
 var postProofType = abi.RegisteredProof_StackedDRG2KiBPoSt
 

--- a/sectorbuilder_test.go
+++ b/sectorbuilder_test.go
@@ -111,8 +111,9 @@ func post(t *testing.T, sb *sectorbuilder.SectorBuilder, seals ...seal) time.Tim
 	sis := make([]abi.SectorInfo, len(seals))
 	for i, s := range seals {
 		sis[i] = abi.SectorInfo{
-			SectorNumber: s.num,
-			SealedCID:    s.sealedCID,
+			RegisteredProof: sealProofType,
+			SectorNumber:    s.num,
+			SealedCID:       s.sealedCID,
 		}
 	}
 

--- a/simple.go
+++ b/simple.go
@@ -7,7 +7,6 @@ import (
 	"io"
 
 	ffi "github.com/filecoin-project/filecoin-ffi"
-	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/specs-actors/actors/abi"
 	"github.com/ipfs/go-cid"
 	"go.opencensus.io/trace"
@@ -23,25 +22,23 @@ type proofVerifier struct{}
 
 var ProofVerifier = proofVerifier{}
 
-func (proofVerifier) VerifySeal(proofType abi.RegisteredProof, sealedCID, unsealedCID cid.Cid, prover address.Address, ticket abi.SealRandomness, seed abi.InteractiveSealRandomness, sectorNum abi.SectorNumber, proof abi.SealProof) (bool, error) {
-	return ffi.VerifySeal(proofType, sealedCID, unsealedCID, addressToProverID(prover), ticket, seed, sectorNum, proof)
+func (proofVerifier) VerifySeal(info abi.SealVerifyInfo) (bool, error) {
+	return ffi.VerifySeal(info)
 }
 
-func (proofVerifier) VerifyElectionPost(ctx context.Context, sectorInfo ffi.SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []abi.PoStCandidate, prover address.Address) (bool, error) {
-	challengeCount := ElectionPostChallengeCount(uint64(len(sectorInfo.Values())), 0)
-	return verifyPost(ctx, sectorInfo, challengeCount, challengeSeed, proof, candidates, prover)
+func (proofVerifier) VerifyElectionPost(ctx context.Context, info abi.PoStVerifyInfo) (bool, error) {
+	return verifyPost(ctx, info)
 }
 
-func (proofVerifier) VerifyFallbackPost(ctx context.Context, sectorInfo ffi.SortedPublicSectorInfo, challengeSeed []byte, proof []byte, candidates []abi.PoStCandidate, prover address.Address, faults uint64) (bool, error) {
-	challengeCount := fallbackPostChallengeCount(uint64(len(sectorInfo.Values())), faults)
-	return verifyPost(ctx, sectorInfo, challengeCount, challengeSeed, proof, candidates, prover)
+func (proofVerifier) VerifyFallbackPost(ctx context.Context, info abi.PoStVerifyInfo) (bool, error) {
+	return verifyPost(ctx, info)
 }
 
-func verifyPost(ctx context.Context, sectorInfo ffi.SortedPublicSectorInfo, challengeCount uint64, challengeSeed abi.PoStRandomness, proof []byte, candidates []abi.PoStCandidate, prover address.Address) (bool, error) {
+func verifyPost(ctx context.Context, info abi.PoStVerifyInfo) (bool, error) {
 	_, span := trace.StartSpan(ctx, "VerifyPoSt")
 	defer span.End()
 
-	return ffi.VerifyPoSt(sectorInfo, challengeSeed, challengeCount, proof, candidates, addressToProverID(prover))
+	return ffi.VerifyPoSt(info)
 }
 
 func GeneratePieceCIDFromFile(proofType abi.RegisteredProof, piece io.Reader, pieceSize abi.UnpaddedPieceSize) (cid.Cid, error) {

--- a/types.go
+++ b/types.go
@@ -71,6 +71,6 @@ type SealRes struct {
 	Err   string
 	GoErr error `json:"-"`
 
-	Proof abi.SealProof
+	Proof []byte
 	Rspco JsonEncodablePreCommitOutput
 }


### PR DESCRIPTION
## Why does this PR exist?

We want v23 Groth parameters!

## What's in this PR?

This PR updates go-sectorbuilder to use v23 Groth parameters and includes updates to conform to new specs-actors code and filecoin-ffi API.