### PR TITLE
expose Seal and PoSt types via sector builder interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.13
 require (
 	github.com/filecoin-project/filecoin-ffi v0.0.0-20200226205820-4da0bccccefb
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
-	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
 	github.com/filecoin-project/go-paramfetch v0.0.2-0.20200218225740-47c639bab663
 	github.com/filecoin-project/specs-actors v0.0.0-20200226200336-94c9b92b2775
 	github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f // indirect

--- a/interface.go
+++ b/interface.go
@@ -16,6 +16,8 @@ type Interface interface {
 
 	AddPiece(context.Context, abi.UnpaddedPieceSize, abi.SectorNumber, io.Reader, []abi.UnpaddedPieceSize) (abi.PieceInfo, error)
 	SectorSize() abi.SectorSize
+	SealProofType() abi.RegisteredProof
+	PoStProofType() abi.RegisteredProof
 	AcquireSectorNumber() (abi.SectorNumber, error)
 	Scrub([]abi.SectorNumber) []*Fault
 

--- a/simple.go
+++ b/simple.go
@@ -18,6 +18,14 @@ func (sb *SectorBuilder) SectorSize() abi.SectorSize {
 	return sb.ssize
 }
 
+func (sb *SectorBuilder) SealProofType() abi.RegisteredProof {
+	return sb.sealProofType
+}
+
+func (sb *SectorBuilder) PoStProofType() abi.RegisteredProof {
+	return sb.postProofType
+}
+
 type proofVerifier struct{}
 
 var ProofVerifier = proofVerifier{}


### PR DESCRIPTION
## Why is this PR needed?

Things which own a sector builder may need to acquire its proof types.

## What's in this PR?

This PR exposes the proof types for a given sector builder.