### PR TITLE
ci: explicitly switch macos build to silicon and upgrade xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
       - when:
           condition: << parameters.linux >>
           steps:
-            - run: sudo apt-get update
+            - run: sudo apt-get update --allow-releaseinfo-change
             - run: sudo apt-get install ocl-icd-opencl-dev
       - run: git submodule sync
       - run: git submodule update --init

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
   build-macos:
     description: build with Darwin
     macos:
-      xcode: "15.0.0"
+      xcode: "14.3.1"
     resource_class: macos.x86.medium.gen2
     working_directory: ~/go/src/github.com/filecoin-project/go-sectorbuilder
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 orbs:
   golang: circleci/go@1.7.3
   go: gotest/tools@0.0.9
-  rust: circleci/rust@1.6.0
 
 executors:
   golang:
@@ -66,7 +65,11 @@ jobs:
   build-all:
     executor: golang
     steps:
-      - rust/install
+      - run:
+          name: Install Rust
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            source "$HOME/.cargo/env"
       - install-deps
       - prepare
       - go/mod-download

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,8 @@ jobs:
   build-macos:
     description: build with Darwin
     macos:
-      xcode: "10.0.0"
+      xcode: "15.0.0"
+    resource_class: macos.x86.medium.gen2
     working_directory: ~/go/src/github.com/filecoin-project/go-sectorbuilder
     steps:
       - prepare:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,11 @@ executors:
 commands:
   install-deps:
     steps:
+      - run:
+          name: Install Rust
+          command: |
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            echo 'export PATH="$HOME"/.cargo/bin:"$PATH"' >> "$BASH_ENV"
       - go/install-ssh
       - go/install: {package: git}
   prepare:
@@ -65,13 +70,6 @@ jobs:
   build-all:
     executor: golang
     steps:
-      - run:
-          name: Install Rust
-          command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            echo 'export PATH="$HOME"/.cargo/bin:"$PATH"' >> "$BASH_ENV"
-      - run:
-          command: which cargo
       - install-deps
       - prepare
       - go/mod-download

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,8 @@ jobs:
       - run:
           name: Install Rust
           command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
-            source "$HOME/.cargo/env"
+            curl https://sh.rustup.rs -sSf | sh -s -- -yecho '
+            export PATH="$HOME"/.cargo/bin:"$PATH"' >> "$BASH_ENV"
       - install-deps
       - prepare
       - go/mod-download

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,8 @@ jobs:
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -yecho '
             export PATH="$HOME"/.cargo/bin:"$PATH"' >> "$BASH_ENV"
+      - run:
+          command: which cargo
       - install-deps
       - prepare
       - go/mod-download

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,6 @@
 version: 2.1
 orbs:
+  golang: circleci/go@1.7.3
   go: gotest/tools@0.0.9
 
 executors:
@@ -120,11 +121,8 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - run:
-          name: Install go
-          command: |
-            curl -O https://dl.google.com/go/go1.13.4.darwin-amd64.pkg && \
-            sudo installer -pkg go1.13.4.darwin-amd64.pkg -target /
+      - golang/install:
+          version: "1.13.4"
       - run:
           name: Install pkg-config
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
       - run:
           name: Install Rust
           command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -yecho '
+            curl https://sh.rustup.rs -sSf | sh -s -- -y
             export PATH="$HOME"/.cargo/bin:"$PATH"' >> "$BASH_ENV"
       - run:
           command: which cargo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   golang: circleci/go@1.7.3
   go: gotest/tools@0.0.9
+  rust: circleci/rust@1.6.0
 
 executors:
   golang:
@@ -65,10 +66,7 @@ jobs:
   build-all:
     executor: golang
     steps:
-      - run:
-          name: Install Rust
-          command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - rust/install
       - install-deps
       - prepare
       - go/mod-download
@@ -114,7 +112,7 @@ jobs:
   build-macos:
     description: build with Darwin
     macos:
-      xcode: "14.3.1"
+      xcode: "13.4.1"
     resource_class: macos.x86.medium.gen2
     working_directory: ~/go/src/github.com/filecoin-project/go-sectorbuilder
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: Install Rust
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
-            export PATH="$HOME"/.cargo/bin:"$PATH"' >> "$BASH_ENV"
+            echo 'export PATH="$HOME"/.cargo/bin:"$PATH"' >> "$BASH_ENV"
       - run:
           command: which cargo
       - install-deps


### PR DESCRIPTION
CircleCI is removing support for Apple Intel executors on Oct 2 - see https://discuss.circleci.com/t/macos-resource-deprecation-update/46891. After that date only Apple Silicon executors will be available. This PR ensures the macos builds are executed on Apple Silicon executors only.